### PR TITLE
Escape vars

### DIFF
--- a/src/main/scala/smt/SyGuSInterface.scala
+++ b/src/main/scala/smt/SyGuSInterface.scala
@@ -110,7 +110,7 @@ class SyGuSInterface(args: List[String], dir : String, sygusFormat : Boolean) ex
     symbolsP.foreach {
       (s) => {
         val sIdP = getVariableName(s.id)
-        variables += (s.id -> (sIdP, s.symbolTyp))
+        variables += (s.id -> Symbol(sIdP, s.symbolTyp))
       }
     }
 
@@ -122,10 +122,10 @@ class SyGuSInterface(args: List[String], dir : String, sygusFormat : Boolean) ex
     val unprimedVars = variables.filter(p => !p._1.endsWith("!"))
     val decls = unprimedVars.map{ v =>
       {
-        val (typeName, otherDecls) = generateDatatype(v._2._2)
+        val (typeName, otherDecls) = generateDatatype(v._2.typ)
         Utils.assert(otherDecls.size == 0, "Datatype declarations are not supported yet.")
         // FIXME: to handle otherDecls
-        declarationCmd.format(v._2._1, typeName)
+        declarationCmd.format(v._2.toString, typeName)
       }
     }.toList
     Utils.join(decls, "\n")
@@ -151,7 +151,7 @@ class SyGuSInterface(args: List[String], dir : String, sygusFormat : Boolean) ex
     symbols.filter(p => !variables.contains(p.id)).foreach {
       (s) => {
         val idP = getVariableName(s.id)
-        variables += (s.id -> (idP -> s.symbolTyp))
+        variables += (s.id -> Symbol(idP, s.symbolTyp))
       }
     }
     val funcBody = translateExpr(initExpr, false)
@@ -164,7 +164,7 @@ class SyGuSInterface(args: List[String], dir : String, sygusFormat : Boolean) ex
     symbols.filter(p => !variables.contains(p.id)).foreach {
       (s) => {
         val idP = getVariableName(s.id)
-        variables += (s.id -> (idP -> s.symbolTyp))
+        variables += (s.id -> Symbol(idP, s.symbolTyp))
       }
     }
     val funcBody = translateExpr(nextExpr, false)

--- a/src/test/scala/smt/SymbolSpec.scala
+++ b/src/test/scala/smt/SymbolSpec.scala
@@ -1,0 +1,39 @@
+package uclid.smt
+import org.scalatest.{FlatSpec, Matchers}
+
+class SymbolSpec extends FlatSpec with Matchers {
+  val t = BoolType
+
+  it should "not escape simple symbols" in {
+    Symbol("a", t).toString should be ("a")
+    Symbol("++", t).toString should be ("++")
+    Symbol("*-", t).toString should be ("*-")
+    Symbol("=a=", t).toString should be ("=a=")
+    Symbol("...", t).toString should be ("...")
+    Symbol("<<<<", t).toString should be ("<<<<")
+    Symbol("@1", t).toString should be ("@1")
+    Symbol("a/b/c", t).toString should be ("a/b/c")
+    Symbol("&~&", t).toString should be ("&~&")
+    Symbol("^_^", t).toString should be ("^_^")
+    Symbol("!?", t).toString should be ("!?")
+  }
+
+  it should "reject ids that cannot be represented" in {
+    assertThrows[AssertionError] { Symbol("|", t) }
+    assertThrows[AssertionError] { Symbol("test|", t) }
+    assertThrows[AssertionError] { Symbol("|test|", t) }
+    assertThrows[AssertionError] { Symbol("\\", t) }
+    assertThrows[AssertionError] { Symbol("test\\", t) }
+  }
+
+  it should "escape symbols when they are not simple" in {
+    Symbol("1", t).toString should be ("|1|")
+    Symbol("1a", t).toString should be ("|1a|")
+    Symbol("", t).toString should be ("||")
+    Symbol(" ", t).toString should be ("| |")
+    Symbol("(select mem test)", t).toString should be ("|(select mem test)|")
+    Symbol("mem[test]", t).toString should be ("|mem[test]|")
+    // the SMTLib spec says "printable characters", not sure if this includes UNICODE
+    Symbol("\uD83D\uDC4D", t).toString should be ("|\uD83D\uDC4D|")
+  }
+}


### PR DESCRIPTION
This makes use of the new escaping capabilities of the `Symbol` class from #7.

This solves some issues I had when using SMTLibInterface with yices and symbol ids that contained `[`.

Unfortunately I am not familiar with the SyGuS Interface, thus someone who is should test the changes before merging this.