### PR TITLE
smt: Array Store/Select: ensure that e is of array type

### DIFF
--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -752,6 +752,7 @@ case class OperatorApplication(op: Operator, operands: List[Expr]) extends Expr 
 case class ArraySelectOperation(e: Expr, index: List[Expr])
   extends Expr (e.typ.asInstanceOf[ArrayType].outType)
 {
+  require(e.typ.isArray, s"Cannot select from an expression of type ${e.typ}: $e")
   override val hashId = 308
   override val hashCode = computeHash(index, e)
   override val md5hashCode = computeMD5Hash(e, index)
@@ -761,6 +762,7 @@ case class ArraySelectOperation(e: Expr, index: List[Expr])
 }
 case class ArrayStoreOperation(e: Expr, index: List[Expr], value: Expr) extends Expr(e.typ)
 {
+  require(e.typ.isArray, s"Cannot store to an expression of type ${e.typ}: $e")
   override val hashId = 309
   override val hashCode = computeHash(index, e, value)
   override val md5hashCode = computeMD5Hash(e, index, value)


### PR DESCRIPTION
This helped me diagnose an expression that was mis-constructed.