### PR TITLE
smt: add option to not return a model from the Context.check method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
 before_script:
-  - wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.6/z3-4.8.6-x64-ubuntu-16.04.zip
-  - unzip z3-4.8.6-x64-ubuntu-16.04.zip
-  - cp z3-4.8.6-x64-ubuntu-16.04/bin/com.microsoft.z3.jar lib/
-  - export PATH=$PATH:$PWD/z3-4.8.6-x64-ubuntu-16.04/bin/
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/z3-4.8.6-x64-ubuntu-16.04/bin/
+  - ./get-z3-linux.sh
+  - ls $PWD/z3/bin/
+  - export PATH=$PATH:$PWD/z3/bin/
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/z3/bin/
 script: sbt ++$TRAVIS_SCALA_VERSION test
 
 

--- a/src/main/scala/uclid/smt/Context.scala
+++ b/src/main/scala/uclid/smt/Context.scala
@@ -207,7 +207,7 @@ abstract trait Context {
   def pop()
   def assert(e: Expr)
   def preassert(e: Expr)
-  def check() : SolverResult
+  def check(produceModel: Boolean = true) : SolverResult
   def checkSynth() : SolverResult
   def finish()
 

--- a/src/main/scala/uclid/smt/SMTLIB2Interface.scala
+++ b/src/main/scala/uclid/smt/SMTLIB2Interface.scala
@@ -413,7 +413,7 @@ class SMTLIB2Interface(args: List[String]) extends Context with SMTLIB2Base {
     }
   }
 
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     smtlibInterfaceLogger.debug("check")
     Utils.assert(solverProcess.isAlive(), "Solver process is not alive!")
     writeCommand("(check-sat)")
@@ -422,7 +422,7 @@ class SMTLIB2Interface(args: List[String]) extends Context with SMTLIB2Base {
         case Some(strP) =>
           val str = strP.stripLineEnd
           str match {
-            case "sat" => SolverResult(Some(true), getModel())
+            case "sat" => SolverResult(Some(true), if(produceModel) getModel() else None)
             case "unsat" => SolverResult(Some(false), None)
             case _ =>
               throw new Utils.AssertionError("Unexpected result from SMT solver: " + str.toString())

--- a/src/main/scala/uclid/smt/SynthLibInterface.scala
+++ b/src/main/scala/uclid/smt/SynthLibInterface.scala
@@ -128,7 +128,7 @@ class SynthLibInterface(args: List[String], sygusSyntax : Boolean) extends SMTLI
     astack = (smtlib2 :: astack.head) :: astack.tail
   }
 
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     synthliblogger.debug("check")
     // put in all the assertions as a conjunction
     total = "(and " + astack.foldLeft(""){ (acc, s) => acc + " " + s.mkString(" ")} + ")" :: total

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -491,7 +491,7 @@ class Z3Interface() extends Context {
 
   lazy val checkLogger = Logger("uclid.smt.Z3Interface.check")
   /** Check whether a particular expression is satisfiable.  */
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     lazy val smtOutput = solver.toString()
     checkLogger.debug(smtOutput)
 
@@ -500,10 +500,13 @@ class Z3Interface() extends Context {
 
       val checkResult : SolverResult = z3Result match {
         case z3.Status.SATISFIABLE =>
-          val z3Model = solver.getModel()
           checkLogger.debug("SAT")
-          checkLogger.debug("Model: {}", z3Model.toString())
-          SolverResult(Some(true), Some(new Z3Model(this, z3Model)))
+          val model = if(produceModel) {
+            val z3Model = solver.getModel()
+            checkLogger.debug("Model: {}", z3Model.toString())
+            Some(new Z3Model(this, z3Model))
+          } else { None }
+          SolverResult(Some(true), model)
         case z3.Status.UNSATISFIABLE =>
           checkLogger.debug("UNSAT")
           SolverResult(Some(false), None)


### PR DESCRIPTION
Sometimes producing a model takes too long and is not needed.