### PR TITLE
code clean up: remove print_smt2

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -309,8 +309,6 @@ class SymbolicSimulator (module : Module) {
             printCEX(proofResults, cmd.args, cmd.argObj)
           case "dump_cex_vcds" =>
             dumpCEXVCDFiles(proofResults)
-          case "print_smt2" =>
-            printSMT2(assertionTree, cmd.argObj, solver)
           case "print_module" =>
             UclidMain.println(module.toString)
           case "set_solver_option" =>
@@ -1314,10 +1312,6 @@ class SymbolicSimulator (module : Module) {
       printFrame(simTable, i, model, exprsToPrint, scope)
       UclidMain.println("=================================")
     }}
-  }
-
-  def printSMT2(aTree : AssertionTree, label : Option[Identifier], solver : smt.Context) {
-    throw new Utils.UnimplementedException("Implement print_smt2.")
   }
 
   def dumpSimTable(simTable : SimulationTable) {

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1373,7 +1373,7 @@ class SymbolicSimulator (module : Module) {
       case BooleanType() => 1
       case BitVectorType(w: Int) => w
       case IntegerType() => defaultIntWidth
-      case _ => throw new Utils.UnimplementedException("VCD dumping supports only bitvector, boolean, and integral types.")
+      case _ => throw new Utils.UnimplementedException("VCD dumping supports only bitvector, boolean, and integer types.")
     }
 
     val vcdWriter = VCD("Top")

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1314,6 +1314,7 @@ class SymbolicSimulator (module : Module) {
     }}
   }
 
+// this function is unused
   def dumpSimTable(simTable : SimulationTable) {
     simTable.foreach {
       println("======================")
@@ -1340,7 +1341,7 @@ class SymbolicSimulator (module : Module) {
       }
     }}
   }
-
+// this function is unused
   def printSymbolTable(symbolTable : SymbolTable) {
     val keys = symbolTable.keys.toList.sortWith((l, r) => l.name < r.name)
     keys.foreach {

--- a/src/main/scala/uclid/lang/ControlCommandChecker.scala
+++ b/src/main/scala/uclid/lang/ControlCommandChecker.scala
@@ -189,7 +189,7 @@ class ControlCommandCheckerPass extends ReadOnlyPass[Unit] {
       case "print_results" =>
         checkNoArgs(cmd, filename)
         checkNoParams(cmd, filename)
-      case "print_cex" | "print_smt2" =>
+      case "print_cex" =>
         checkNoParams(cmd, filename)
         checkNoResultVar(cmd, filename)
         checkHasArgObj(cmd, filename)

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -706,7 +706,7 @@ case class BitVectorLit(value: BigInt, width: Int) extends NumericLit {
   override def to (n : NumericLit) : Seq[NumericLit] = {
     n match {
       case bv : BitVectorLit => (value to bv.value).map(BitVectorLit(_, width))
-      case _ => throw new Utils.RuntimeError("Cannot create range for differening types of numeric literals.")
+      case _ => throw new Utils.RuntimeError("Cannot create range for differing types of numeric literals.")
     }
   }
   override def negate = BitVectorLit(-value, width)

--- a/src/main/scala/uclid/vcd/VCD.scala
+++ b/src/main/scala/uclid/vcd/VCD.scala
@@ -59,9 +59,6 @@ object VCD extends LazyLogging {
   val DumpVarsDeclaration: String = "$dumpvars"
   val End: String = "$end"
 
-  private val ClockName = "clock"
-  private val ResetName = "reset"
-
   val idChars: Seq[String] = (33 to 126).map { asciiValue => asciiValue.toChar.toString }
   val numberOfIdChars: Int = idChars.length
 


### PR DESCRIPTION
This function was not implemented, and it's not clear how it was supposed to be used. It is superseded by the command line option -g.