### PR TITLE
[WIP] Initial commit to dump_c

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -313,6 +313,8 @@ class SymbolicSimulator (module : Module) {
             printSMT2(assertionTree, cmd.argObj, solver)
           case "print_module" =>
             UclidMain.println(module.toString)
+          case "dump_c" =>
+            UclidMain.println(module.dumpC)  
           case "set_solver_option" =>
             val option = cmd.args(0)._1.asInstanceOf[lang.StringLit].value
             val value : smt.Context.SolverOption = cmd.args(1)._1 match {

--- a/src/main/scala/uclid/lang/ControlCommandChecker.scala
+++ b/src/main/scala/uclid/lang/ControlCommandChecker.scala
@@ -176,7 +176,7 @@ class ControlCommandCheckerPass extends ReadOnlyPass[Unit] {
         checkParamIsALogic(cmd, context, filename)
         checkNoArgObj(cmd, filename)
         checkNoResultVar(cmd, filename)
-      case "check" | "print_module" =>
+      case "check" | "print_module" | "dump_c" =>
         checkNoArgs(cmd, filename)
         checkNoParams(cmd, filename)
         checkNoArgObj(cmd, filename)


### PR DESCRIPTION
Work in progress but please provide feedback!

Using the command dump_c, uclid will spit out a C file that can
be either compiled or fed to another verification tool.

At the moment supported verification commands are: unroll and induction
The syntax is currently CBMC specific, but will be adapted in future to work
for any SV comp tool. 

The aim is that we can:
- execute uclid models in C
- compare uclid against other verification tools that compete in sv comp
- try out existing program slicing and abstraction techniques on uclid models