### PR TITLE
New tests for inlining

### DIFF
--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -210,6 +210,21 @@ class ProcedureVerifSpec extends FlatSpec {
   "test-inliner-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-inliner-1.ucl", 0)
   }
+  "test-procedure-inline.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-procedure-inline.ucl", 0)
+  }
+  "test-procedure-inline-2.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-procedure-inline-2.ucl", 0)
+  }
+  "test-procedure-inline-3.ucl" should "verify all but 1" in {
+    VerifierSpec.expectedFails("./test/test-procedure-inline-3.ucl", 1)
+  }
+  "test-procedure-noinline.ucl" should "verify all but 1 assertion successfully" in {
+    VerifierSpec.expectedFails("./test/test-procedure-noinline.ucl", 1)
+  }
+  // "test-procedure-noinline-2.ucl" should "fail" in {
+  //   VerifierSpec.expectedFails("./test/test-procedure-noinline-2.ucl", 1)
+  // }
   "test-procedure-checker-2.ucl" should "verify all but 4 invariants successfully." in {
     VerifierSpec.expectedFails("./test/test-procedure-checker-2.ucl", 4)
   }

--- a/test/test-procedure-inline-2.ucl
+++ b/test/test-procedure-inline-2.ucl
@@ -1,0 +1,27 @@
+
+module main {
+    var v : integer;
+
+  procedure [inline] incr()
+  requires true;
+  ensures true;
+    modifies v;
+    {
+        assert(v==0);
+    }
+
+    procedure test()
+    modifies v;
+    {
+        v = 0;
+        call () = incr();
+        assert(v==0);
+    }
+
+    control {
+        v = verify(test); // 2 assertions should pass
+        check;
+        print_results;
+    }
+}
+

--- a/test/test-procedure-inline-3.ucl
+++ b/test/test-procedure-inline-3.ucl
@@ -1,0 +1,27 @@
+
+module main {
+  var v : integer;
+
+  procedure [inline] incr()
+  requires v>0; // should fail
+  ensures true;
+  modifies v;
+  {
+    assert(v==0);
+  }
+
+  procedure test()
+  modifies v;
+  {
+    v = 0;
+    call () = incr();
+    assert(v==0); 
+  }
+
+  control {
+    v = verify(test); // should pass
+    check;
+    print_results;
+  }
+}
+

--- a/test/test-procedure-inline.ucl
+++ b/test/test-procedure-inline.ucl
@@ -1,0 +1,24 @@
+
+module main {
+    var v : integer;
+
+  procedure [inline] incr()
+    modifies v;
+    {
+        assert(v==0);
+    }
+
+    procedure test()
+    modifies v;
+    {
+        v = 0;
+        call () = incr();
+        assert(v==0);
+    }
+
+    control {
+        v = verify(test); // 2 assertions should pass
+        check;
+        print_results;
+    }
+}

--- a/test/test-procedure-noinline-2.ucl
+++ b/test/test-procedure-noinline-2.ucl
@@ -1,0 +1,23 @@
+
+module main {
+    var v : integer;
+
+  procedure [noinline] incr()
+    modifies v;
+    {
+        assert(v==0);
+    }
+    init {
+        v = 0;
+        call () = incr();
+    }
+    next{}
+
+    invariant myinv: v==0;
+
+    control {
+        v = induction; // should fail
+        check;
+        print_results;
+    }
+}

--- a/test/test-procedure-noinline.ucl
+++ b/test/test-procedure-noinline.ucl
@@ -1,0 +1,25 @@
+
+module main {
+    var v : integer;
+
+  procedure [noinline] incr()
+  requires true;
+  ensures true;
+        modifies v;
+    {
+        assert(v==0);
+    }
+    init {
+        v = 0;
+        call () = incr();
+    }
+    next{}
+
+    invariant myinv: v==0;
+
+    control {
+        v = induction; // 2 assertions pass, 1 should fail
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
This is the current behaviour

![image](https://user-images.githubusercontent.com/17899331/85811079-e3a83480-b711-11ea-8dcd-9ee12574f4c3.png)

We agreed in the UCLID meeting that the behaviour should be:
all procedures with the [inline] directive are inlined
all procedures with the [noinline] directive are no-inlined
all procedures with no directive are inlined

One of these tests is commented out because it currently fails because the current behaviour doesn't match the decided upon behaviour. 
