### PR TITLE
Removing additional blockflattener pass

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -223,7 +223,6 @@ object UclidMain {
     passManager.addPass(new BitVectorSliceConstify())
     passManager.addPass(new VariableDependencyFinder())
     passManager.addPass(new StatementScheduler())
-    passManager.addPass(new BlockFlattener())
     passManager.addPass(new NewInternalProcedureInliner())
     passManager.addPass(new PrimedVariableCollector())
     passManager.addPass(new PrimedVariableEliminator())


### PR DESCRIPTION
This block flattener pass doesn't seem necessary. If it is necessary, we should add some tests that fail when it is removed