### PR TITLE
replace symbolic simulator for unroll

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -195,8 +195,12 @@ class SymbolicSimulator (module : Module) {
             }
             // get_init_lambda(false, context, "some")
             val properties : List[Identifier] = extractProperties(Identifier("properties"), cmd.params)
-            symbolicSimulateLambdas(0, cmd.args(0)._1.asInstanceOf[IntLit].value.toInt, true, false, 
-                                    context, label, createNoLTLFilter(properties), createNoLTLFilter(properties), solver)
+            initialize(false, true, false, context, label, createNoLTLFilter(properties), createNoLTLFilter(properties))
+            symbolicSimulate(0, cmd.args(0)._1.asInstanceOf[IntLit].value.toInt, true, false, context, label, 
+                            createNoLTLFilter(properties), createNoLTLFilter(properties))
+
+            // symbolicSimulateLambdas(0, cmd.args(0)._1.asInstanceOf[IntLit].value.toInt, true, false, 
+            //                         context, label, createNoLTLFilter(properties), createNoLTLFilter(properties), solver)
           case "horn" =>
             val label : String = cmd.resultVar match {
               case Some(l) => l.toString

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1310,7 +1310,11 @@ class SymbolicSimulator (module : Module) {
     (0 to lastFrame).foreach{ case (i) => {
       UclidMain.println("=================================")
       UclidMain.println("Step #" + i.toString)
-      printFrame(simTable, i, model, exprsToPrint, scope)
+      try{
+          printFrame(simTable, i, model, exprsToPrint, scope)
+      }  catch{
+            case _: Throwable => UclidMain.println("error: unable to parse counterexample frame")
+      }
       UclidMain.println("=================================")
     }}
   }


### PR DESCRIPTION
This needs reviewing please.

I've replaced the symbolicSimulateLambdas function with symbolicSimulate for unroll, because symbolicSimulateLambdas was performing significantly slower (>10 minutes vs 5s) on an example Shaokai posted. I'll attach the example to a comment in this PR. 

The function that appears to be taking a long time is this https://github.com/uclid-org/uclid/blob/master/src/main/scala/uclid/SymbolicSimulator.scala#L801:
~~~
val next_conjunct = substitute(betaSubstitution(next_lambda._1, (prevVarTable(j - 1) ++ new_vars).flatten), havoc_subs)
~~~

This change has exposed one new bug in the SMTLib interface that I will try to fix. 

The main reason I want this reviewed is that I'm not sure if this change has broken the hyperproperties. All of the regression tests pass, but i believe symbolicSimulateLambdas is supposed to support hyperproperties where symbolicSimulate does not? I'm not clear on the details of how hyperproperty verification has been implemented. 
