### PR TITLE
catch counterexample parsing errors

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1306,7 +1306,11 @@ class SymbolicSimulator (module : Module) {
     (0 to lastFrame).foreach{ case (i) => {
       UclidMain.println("=================================")
       UclidMain.println("Step #" + i.toString)
-      printFrame(simTable, i, model, exprsToPrint, scope)
+      try{
+          printFrame(simTable, i, model, exprsToPrint, scope)
+      }  catch{
+            case _: Throwable => UclidMain.println("error: unable to parse counterexample frame")
+      }
       UclidMain.println("=================================")
     }}
   }


### PR DESCRIPTION
Catch, print error message and continue if we are unable to parse the counterexample correctly. 

As a user, I would prefer this behaviour since I do at least get to see the result of the verification query, but it does mean we need to add more thorough tests for counterexample parsing somewhere in the regression test suite