### PR TITLE
Program synth grammar kkmc

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -117,7 +117,7 @@ class SymbolicSimulator (module : Module) {
   def newSynthSymbol(name: String, t: FunctionSig, gid : Option[Identifier], gargs: List[Identifier], conds : List[Expr]) = {
     new smt.SynthSymbol("synth_" + name, t, gid, gargs, conds)
   }
-  def newGrammarSymbol(name: String, t: smt.Type, nts: List[NonTerminal]) = {
+  def newGrammarSymbol(name: String, t: smt.Type, nts: List[smt.NonTerminal]) = {
     new smt.GrammarSymbol("grammar_" + name, t, nts)
   }
   def newTaintSymbol(name: String, t: smt.Type) = {
@@ -342,7 +342,7 @@ class SymbolicSimulator (module : Module) {
           case Scope.OutputVar(id, typ) => mapAcc + (id -> newInitSymbol(id.name, smt.Converter.typeToSMT(typ)))
           case Scope.StateVar(id, typ) => mapAcc + (id -> newInitSymbol(id.name, smt.Converter.typeToSMT(typ)))
           case Scope.SharedVar(id, typ) => mapAcc + (id -> newInitSymbol(id.name, smt.Converter.typeToSMT(typ)))
-          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> newGrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts))
+          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> newGrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts.map(smt.Converter.nonTerminalToSMT(_, scope))))
           case _ => mapAcc
         }
       }
@@ -1488,6 +1488,7 @@ class SymbolicSimulator (module : Module) {
         isStatelessExpr(fapp.e, context) && fapp.args.forall(a => isStatelessExpr(a, context))
       case lambda : Lambda =>
         isStatelessExpr(lambda.e, context + lambda)
+      // case FuncAppTerm(_, _) | OpAppTerm(_, _) => throw new Utils.RuntimeError("Grammar terms should not be part of model expressions.")
     }
   }
 
@@ -1561,7 +1562,7 @@ class SymbolicSimulator (module : Module) {
           case Scope.OutputVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name, smt.Converter.typeToSMT(typ)))
           case Scope.StateVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name, smt.Converter.typeToSMT(typ)))
           case Scope.SharedVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name, smt.Converter.typeToSMT(typ)))
-          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts))
+          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts.map(smt.Converter.nonTerminalToSMT(_, scope))))
           case _ => mapAcc
         }
       }
@@ -1579,7 +1580,7 @@ class SymbolicSimulator (module : Module) {
           case Scope.OutputVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "$" + index.toString(), smt.Converter.typeToSMT(typ)))
           case Scope.StateVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "$" + index.toString(), smt.Converter.typeToSMT(typ)))
           case Scope.SharedVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "$" + index.toString(), smt.Converter.typeToSMT(typ)))
-          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts))
+          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts.map(smt.Converter.nonTerminalToSMT(_, scope))))
           case _ => mapAcc
         }
       }
@@ -1597,7 +1598,7 @@ class SymbolicSimulator (module : Module) {
           case Scope.OutputVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "!", smt.Converter.typeToSMT(typ)))
           case Scope.StateVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "!", smt.Converter.typeToSMT(typ)))
           case Scope.SharedVar(id, typ) => mapAcc + (id -> smt.Symbol(id.name + "!", smt.Converter.typeToSMT(typ)))
-          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts))
+          case Scope.Grammar(id, typ, nts) => mapAcc + (id -> smt.GrammarSymbol(id.name, smt.Converter.typeToSMT(typ), nts.map(smt.Converter.nonTerminalToSMT(_, scope))))
           case _ => mapAcc
         }
       }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -328,7 +328,7 @@ object UclidMain {
       logger.debug("args: {}", config.smtSolver)
       new smt.SMTLIB2Interface(config.smtSolver)
     } else if (config.synthesizer.size > 0) {
-      new smt.SynthLibInterface(config.synthesizer, config.sygusFormat)
+      new smt.SynthLibInterface(config.synthesizer, config.sygusFormat, module)
     } else {
       new smt.Z3Interface()
     }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -205,6 +205,7 @@ object UclidMain {
     passManager.addPass(new BitVectorSliceFindWidth())
     passManager.addPass(new ExpressionTypeChecker())
     if (!test) passManager.addPass(new VerificationExpressionChecker())
+    passManager.addPass(new PolymorphicGrammarTypeRewriter())
     passManager.addPass(new PolymorphicTypeRewriter())
     passManager.addPass(new FindProcedureDependency())
     passManager.addPass(new DefDepGraphChecker())

--- a/src/main/scala/uclid/lang/ASTVistors.scala
+++ b/src/main/scala/uclid/lang/ASTVistors.scala
@@ -179,8 +179,15 @@ trait RewritePass {
   def rewriteProcedure(proc : ProcedureDecl, ctx : Scope) : Option[ProcedureDecl] = { Some(proc) }
   def rewriteFunction(func : FunctionDecl, ctx : Scope) : Option[FunctionDecl] = { Some(func) }
   def rewriteModuleFunctionsImport(modFuncImport : ModuleFunctionsImportDecl, ctx : Scope) : Option[ModuleFunctionsImportDecl] = { Some(modFuncImport) }
+  def rewriteFuncAppTerm(term : FuncAppTerm, ctx : Scope) : Option[FuncAppTerm] = { Some(term) }
+  def rewriteOpAppTerm(term : OpAppTerm, ctx : Scope) : Option[OpAppTerm] = { Some(term) }
+  def rewriteLiteralTerm(term : LiteralTerm, ctx : Scope) : Option[LiteralTerm] = { Some(term) }
+  def rewriteSymbolTerm(term : SymbolTerm, ctx : Scope) : Option[SymbolTerm] = { Some(term) }
+  def rewriteConstantTerm(term : ConstantTerm, ctx : Scope) : Option[ConstantTerm] = { Some(term) }
+  def rewriteVariableTerm(term : VariableTerm, ctx : Scope) : Option[VariableTerm] = { Some(term) }
   def rewriteNonterminal(nonterm : NonTerminal, ctx : Scope) : Option[NonTerminal] = { Some(nonterm) }
   def rewriteGrammar(grammar : GrammarDecl, ctx : Scope) : Option[GrammarDecl] = { Some(grammar) }
+  def rewriteGrammarTerm(term: GrammarTerm, ctx: Scope) : Option[GrammarTerm] = { Some(term) }
   def rewriteSynthesisFunction(synFunc : SynthesisFunctionDecl, ctx : Scope) : Option[SynthesisFunctionDecl] = { Some(synFunc) }
   def rewriteDefine(defDecl : DefineDecl, ctx : Scope) : Option[DefineDecl] = { Some(defDecl) }
   def rewriteModuleDefinesImport(modDefImport : ModuleDefinesImportDecl, ctx : Scope) : Option[ModuleDefinesImportDecl] = { Some(modDefImport) }
@@ -1213,9 +1220,85 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
     }
     return ASTNode.introducePos(setPosition, setFilename, modFuncImpP, modFuncImp.position)
   }
-    
-  def visitNonterminals(nonterms : List[NonTerminal], context : Scope) : List[NonTerminal] = {
-    nonterms.map(nt => ASTNode.introducePos(setPosition, setFilename, pass.rewriteNonterminal(nt, context), nt.position)).flatten
+
+  def visitFuncAppTerm(funcAppTerm: FuncAppTerm, context: Scope) : Option[FuncAppTerm] = {
+    val idP = visitIdentifier(funcAppTerm.id, context)
+    val argsP = funcAppTerm.args.map(visitGrammarTerm(_, context)).flatten
+    val funcAppTermP = idP match {
+      case Some(id) => pass.rewriteFuncAppTerm(FuncAppTerm(id, argsP), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, funcAppTermP, funcAppTerm.position)
+  }
+
+  def visitOpAppTerm(opAppTerm: OpAppTerm, context: Scope) : Option[OpAppTerm] = {
+    val opP = visitOperator(opAppTerm.op, context)
+    val argsP = opAppTerm.args.map(visitGrammarTerm(_, context)).flatten
+    val opAppTermP = opP match {
+      case Some(op) => pass.rewriteOpAppTerm(OpAppTerm(op, argsP), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, opAppTermP, opAppTerm.position)
+  }
+
+  def visitLiteralTerm(litTerm: LiteralTerm, context: Scope) : Option[LiteralTerm] = {
+    val litP = visitLiteral(litTerm.lit, context)
+    val litTermP = litP match {
+      case Some(lit) => pass.rewriteLiteralTerm(LiteralTerm(lit.asInstanceOf[Literal]), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, litTermP, litTerm.position)
+  }
+
+  def visitSymbolTerm(symTerm: SymbolTerm, context: Scope) : Option[SymbolTerm] = {
+    val idP = visitIdentifier(symTerm.id, context)
+    val symTermP = idP match {
+      case Some(id) => pass.rewriteSymbolTerm(SymbolTerm(id), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, symTermP, symTerm.position)
+  }
+
+  def visitConstantTerm(constTerm: ConstantTerm, context: Scope) : Option[ConstantTerm] = {
+    val typP = visitType(constTerm.typ, context)
+    val constTermP = typP match {
+      case Some(typ) => pass.rewriteConstantTerm(ConstantTerm(typ), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, constTermP, constTerm.position)
+  }
+
+  def visitVariableTerm(varTerm: VariableTerm, context: Scope) : Option[VariableTerm] = {
+    val typP = visitType(varTerm.typ, context)
+    val varTermP = typP match {
+      case Some(typ) => pass.rewriteVariableTerm(VariableTerm(typ), context)
+      case None => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, varTermP, varTerm.position)
+  }
+
+  def visitGrammarTerm(grammarTerm: GrammarTerm, context: Scope) : Option[GrammarTerm] = {
+    val grammarTermP = grammarTerm match {
+      case funcAppTerm: FuncAppTerm => visitFuncAppTerm(funcAppTerm, context)
+      case opAppTerm: OpAppTerm => visitOpAppTerm(opAppTerm, context)
+      case litTerm: LiteralTerm => visitLiteralTerm(litTerm, context)
+      case symTerm: SymbolTerm => visitSymbolTerm(symTerm, context)
+      case constTerm: ConstantTerm => visitConstantTerm(constTerm, context)
+      case varTerm: VariableTerm => visitVariableTerm(varTerm, context)
+      case _ => throw new Utils.UnimplementedException("Grammar term visit unimplemented.")
+    }
+    return ASTNode.introducePos(setPosition, setFilename, grammarTermP, grammarTerm.position)
+  }
+
+  def visitNonterminal(nonTerm: NonTerminal, context: Scope) : Option[NonTerminal] = {
+    val idP = visitIdentifier(nonTerm.id, context)
+    val typP = visitType(nonTerm.typ, context)
+    val termsP = nonTerm.terms //nonTerm.terms.map(visitGrammarTerm(_)).flatten
+    val nonTermP = (idP, typP) match {
+      case (Some(id), Some(typ)) => pass.rewriteNonterminal(NonTerminal(id, typ, termsP), context)
+      case _ => None
+    }
+    return ASTNode.introducePos(setPosition, setFilename, nonTermP, nonTerm.position)
   }
 
   def visitModuleTypesImport(modTypImp : ModuleTypesImportDecl, context : Scope) : Option[ModuleTypesImportDecl] = {
@@ -1230,7 +1313,7 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
   def visitGrammar(grammar: GrammarDecl, context: Scope) : Option[GrammarDecl] = {
     val idOpt = visitIdentifier(grammar.id, context)
     val sigOpt = visitFunctionSig(grammar.sig, context)
-    val nonterminalsP = visitNonterminals(grammar.nonterminals, context + grammar.sig)
+    val nonterminalsP = grammar.nonterminals.map(visitNonterminal(_, context + grammar.sig)).flatten
     val grammarP = (idOpt, sigOpt) match {
       case (Some(id), Some(sig)) => pass.rewriteGrammar(GrammarDecl(id, sig, nonterminalsP), context)
       case _ => None

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -80,7 +80,8 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |
                Scope.AxiomVar(_ , _, _)       | Scope.VerifResultVar(_, _)      |
-               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          =>
+               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          |
+               Scope.NonTerminal(_, _, _) =>
              throw new Utils.ParserError("Can't have this identifier in define declaration: " + namedExpr.toString(), None, None)
         }
       case None =>

--- a/src/main/scala/uclid/lang/Scope.scala
+++ b/src/main/scala/uclid/lang/Scope.scala
@@ -57,7 +57,8 @@ object Scope {
   case class ConstantLit(cId : Identifier, lit : NumericLit) extends ReadOnlyNamedExpression(cId, lit.typeOf)
   case class ConstantVar(cId : Identifier, cTyp : Type) extends ReadOnlyNamedExpression(cId, cTyp)
   case class Function(fId : Identifier, fTyp: Type) extends ReadOnlyNamedExpression(fId, fTyp)
-  case class Grammar(gId : Identifier, gTyp : Type, nts : List[NonTerminal]) extends ReadOnlyNamedExpression(gId, gTyp)
+  case class Grammar(gId : Identifier, gTyp : Type, nts : List[lang.NonTerminal]) extends ReadOnlyNamedExpression(gId, gTyp)
+  case class NonTerminal(ntId: Identifier, ntTyp: Type, terms: List[GrammarTerm]) extends ReadOnlyNamedExpression(ntId, ntTyp)
   case class SynthesisFunction(fId : Identifier, fTyp: FunctionSig, gId: Option[Identifier], gargs: List[Identifier], conds : List[Expr]) extends ReadOnlyNamedExpression(fId, fTyp.typ)
   case class Define(dId : Identifier, dTyp : Type, defDecl: DefineDecl) extends ReadOnlyNamedExpression(dId, dTyp)
   case class Procedure(pId : Identifier, pTyp: Type) extends ReadOnlyNamedExpression(pId, pTyp)
@@ -337,6 +338,11 @@ case class Scope (
     val newMap = sig.args.foldLeft(map){
       (mapAcc, id) => Scope.addToMap(mapAcc, Scope.FunctionArg(id._1, id._2))
     }
+    return Scope(newMap, module, procedure, cmd, environment, Some(this))
+  }
+  /** Return a new context with the nonterminal included. */
+  def +(nt: NonTerminal): Scope = {
+    val newMap = Scope.addToMap(map, Scope.NonTerminal(nt.id, nt.typ, nt.terms))
     return Scope(newMap, module, procedure, cmd, environment, Some(this))
   }
   /** Return a new context with effect of operator added. */

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -79,7 +79,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |
                Scope.AxiomVar(_ , _, _)       | Scope.VerifResultVar(_, _)      |
-               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          =>
+               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          |
+               Scope.NonTerminal(_, _, _) =>
              throw new Utils.RuntimeError("Can't have this identifier in assertion: " + namedExpr.toString())
         }
       case None =>
@@ -128,7 +129,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.VerifResultVar(_, _)     | Scope.FunctionArg(_, _)         |
                Scope.Define(_, _, _)          | Scope.Grammar(_, _, _)          |
                Scope.ConstantLit(_, _)        | Scope.BlockVar(_, _)            |
-               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          =>
+               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          |
+               Scope.NonTerminal(_, _, _) =>
               id
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.SynthesisFunction(_, _, _, _, _) =>
              ExternalIdentifier(moduleName, id)

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -697,4 +697,3 @@ class PolymorphicTypeRewriterPass extends RewritePass {
 }
 class PolymorphicTypeRewriter extends ASTRewriter(
     "PolymorphicTypeRewriter", new PolymorphicTypeRewriterPass())
-

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -668,22 +668,25 @@ sealed abstract class Literal extends Expr {
   /** All literals are constants. */
   override def isConstant = true
   def isNumeric = false
+  def typeOf: Type
 }
 /** A non-deterministic new constant. */
 case class FreshLit(typ : Type) extends Literal {
   override def toString = "*"
   override val hashId = 2200
+  override def typeOf: Type = typ
   override val md5hashCode = computeMD5Hash(typ)
 }
 sealed abstract class NumericLit extends Literal {
   override def isNumeric = true
-  def typeOf : NumericType
+  override def typeOf : NumericType
   def to (n : NumericLit) : Seq[NumericLit]
   def negate: NumericLit
 }
 case class BoolLit(value: Boolean) extends Literal {
   override def toString = value.toString
   override val hashId = 2201
+  override def typeOf: Type = BooleanType()
   override val md5hashCode = computeMD5Hash(value)
 }
 case class IntLit(value: BigInt) extends NumericLit {
@@ -717,6 +720,7 @@ case class BitVectorLit(value: BigInt, width: Int) extends NumericLit {
 case class StringLit(value: String) extends Literal {
   override def toString = "\"" + value + "\""
   override val hashId = 2202
+  override def typeOf: Type = StringType()
   override val md5hashCode = computeMD5Hash(value)
 }
 

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1818,8 +1818,12 @@ case class Module(id: Identifier, decls: List[Decl], cmds : List[GenericProofCom
   
   // module macros
   lazy val defines : List[DefineDecl] = decls.collect{ case d : DefineDecl => d }
+  
   lazy val synthFunctions: List[SynthesisFunctionDecl] =
     decls.filter(_.isInstanceOf[SynthesisFunctionDecl]).map(_.asInstanceOf[SynthesisFunctionDecl])
+  
+  lazy val grammarDecls: List[GrammarDecl] = decls.collect { case gDecl: GrammarDecl => gDecl }
+
   // module properties.
   lazy val properties : List[SpecDecl] = decls.collect{ case spec : SpecDecl => spec }
 

--- a/src/main/scala/uclid/smt/Converter.scala
+++ b/src/main/scala/uclid/smt/Converter.scala
@@ -352,11 +352,21 @@ object Converter {
     }
   }
 
-  def nonTerminalToSMT(nt: lang.NonTerminal, scope: lang.Scope): smt.NonTerminal = {
-    smt.NonTerminal(nt.id.name, typeToSMT(nt.typ), nt.terms.map(grammarTermToSMT(_, scope)))
+  /** Convert a Uclid NonTerminal to SMT/SyGuS Nonterminal
+   *
+   *  @nt Uclid Nonterminal to convert
+   *  @scope context used for type information
+   */
+  def nonTerminalToSyGuS2(nt: lang.NonTerminal, scope: lang.Scope): smt.NonTerminal = {
+    smt.NonTerminal(nt.id.name, typeToSMT(nt.typ), nt.terms.map(grammarTermToSyGuS2(_, scope)))
   }
 
-  def grammarTermToSMT(gt: lang.GrammarTerm, scope: lang.Scope): smt.GrammarTerm = {
+  /** Convert a Uclid GrammarTerm to SMT/SyGuS GrammarTerm
+   *
+   *  @gt Uclid GrammarTerm to convert
+   *  @scope context used for type information
+   */
+  def grammarTermToSyGuS2(gt: lang.GrammarTerm, scope: lang.Scope): smt.GrammarTerm = {
     def idToSMT(id : lang.Identifier, scope : lang.Scope, past : Int) : smt.Expr = {
       val typ = scope.typeOf(id) match {
         case Some(typ) => typeToSMT(typ)
@@ -366,12 +376,12 @@ object Converter {
     }
     val expr = gt match {
       case lang.FuncAppTerm(id, args) => {
-        val argsP = args.foldLeft(List.empty[GrammarTerm])((acc, arg) => acc :+ grammarTermToSMT(arg, scope))
+        val argsP = args.foldLeft(List.empty[GrammarTerm])((acc, arg) => acc :+ grammarTermToSyGuS2(arg, scope))
         smt.FunctionApplication(smt.Symbol(id.name, typeToSMT(scope.typeOf(id).get)), argsP)
       }
       case lang.OpAppTerm(op, args) => {
         val opP = opToSMT(op, scope, 0, idToSMT)
-        val argsP = args.foldLeft(List.empty[GrammarTerm])((acc, arg) => acc :+ grammarTermToSMT(arg, scope))
+        val argsP = args.foldLeft(List.empty[GrammarTerm])((acc, arg) => acc :+ grammarTermToSyGuS2(arg, scope))
         smt.OperatorApplication(opP, argsP)
       }
       case lang.LiteralTerm(lit: lang.Literal) => _exprToSMT(lit, scope, 0, idToSMT)

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -822,12 +822,6 @@ case class AssignmentModel(functions : List[Expr]) extends Hashable {
   override val md5hashCode = computeMD5Hash(functions)
   override def toString = Utils.join(functions.map(fun => fun.toString()), " ")
 }
-case class SynthSymbol(id: String, symbolTyp: lang.FunctionSig, gid: Option[Identifier], gargs: List[Identifier], conds : List[lang.Expr]) extends Expr (smt.Converter.typeToSMT(symbolTyp.typ)) {
-  override val hashId = mix(id.hashCode(), mix(symbolTyp.typ.hashCode(), 315))
-  override val hashCode = computeHash
-  override val md5hashCode = computeMD5Hash(id, symbolTyp.typ)
-  override def toString = id.toString
-}
 
 class Bindings(val freeVars : List[Symbol], val letVars : List[Symbol], val lambdaVars : List[Symbol], val quantifierVars: List[Symbol]) {
   def addFreeVar(v : Symbol) = {

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -40,7 +40,6 @@ package uclid
 package smt
 import scala.util.matching.Regex
 import uclid.lang.Identifier
-import uclid.lang.NonTerminal
 
 sealed trait Type extends Hashable {
   override val hashBaseId = 22575 // Random number. Not super important, must just be unique for each abstract base class.
@@ -827,12 +826,6 @@ case class SynthSymbol(id: String, symbolTyp: lang.FunctionSig, gid: Option[Iden
   override val hashId = mix(id.hashCode(), mix(symbolTyp.typ.hashCode(), 315))
   override val hashCode = computeHash
   override val md5hashCode = computeMD5Hash(id, symbolTyp.typ)
-  override def toString = id.toString
-}
-case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) extends Expr (symbolTyp) {
-  override val hashId = mix(id.hashCode(), mix(symbolTyp.hashCode(), 316))
-  override val hashCode = computeHash
-  override val md5hashCode = computeMD5Hash(id, symbolTyp)
   override def toString = id.toString
 }
 

--- a/src/main/scala/uclid/smt/SyGuSIF2Language.scala
+++ b/src/main/scala/uclid/smt/SyGuSIF2Language.scala
@@ -1,0 +1,67 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2017.
+ * Sanjit A. Seshia, Rohit Sinha and Pramod Subramanyan.
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors: Kevin Cheang
+ *
+ * SyGuS-IF 2.0 AST definition (extends SMTLanguage).
+ *
+ */
+package uclid
+package smt
+
+case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) extends Expr (symbolTyp) {
+  override val hashId = mix(id.hashCode(), mix(symbolTyp.hashCode(), 316))
+  override val hashCode = computeHash
+  override val md5hashCode = computeMD5Hash(id, symbolTyp)
+  override def toString = {
+  	val nonTermDecls = Utils.join(nts.map(nt => "(" + nt.id + " " + nt.typ.toString + ")"), " ")
+  	val grammarDecl = Utils.join(nts.map(_.toString), " ")
+  	"((%s) (%s))".format(nonTermDecls, grammarDecl)
+  }
+}
+
+case class NonTerminal(id: String, typ: Type, terms: List[GrammarTerm]) extends Hashable {
+  override val hashId = 4100
+  override val hashBaseId = 4100
+  override def toString = {
+    "(%s %s (%s))".format(id.toString, typ.toString, Utils.join(terms.map("(" + _.toString + ")"), " "))
+  }
+  override val md5hashCode = computeMD5Hash(id, typ, terms)
+}
+
+case class GrammarTerm(e: Expr) extends Expr(e.typ) {
+  override val hashId = 4101
+  override val hashBaseId = 4101
+  override def toString = e.toString
+  override val md5hashCode = computeMD5Hash(e)
+}

--- a/src/main/scala/uclid/smt/SyGuSIF2Language.scala
+++ b/src/main/scala/uclid/smt/SyGuSIF2Language.scala
@@ -39,6 +39,13 @@
 package uclid
 package smt
 
+case class SynthSymbol(id: String, symbolTyp: lang.FunctionSig, grammar: Option[GrammarSymbol], gargs: List[String], conds : List[lang.Expr]) extends Expr (smt.Converter.typeToSMT(symbolTyp.typ)) {
+  override val hashId = mix(id.hashCode(), mix(symbolTyp.typ.hashCode(), 315))
+  override val hashCode = computeHash
+  override val md5hashCode = computeMD5Hash(id, symbolTyp.typ)
+  override def toString = id.toString
+}
+
 case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) extends Expr (symbolTyp) {
   override val hashId = mix(id.hashCode(), mix(symbolTyp.hashCode(), 316))
   override val hashCode = computeHash
@@ -46,7 +53,7 @@ case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) e
   override def toString = {
   	val nonTermDecls = Utils.join(nts.map(nt => "(" + nt.id + " " + nt.typ.toString + ")"), " ")
   	val grammarDecl = Utils.join(nts.map(_.toString), " ")
-  	"((%s) (%s))".format(nonTermDecls, grammarDecl)
+  	"(%s) (%s)".format(nonTermDecls, grammarDecl)
   }
 }
 
@@ -54,7 +61,7 @@ case class NonTerminal(id: String, typ: Type, terms: List[GrammarTerm]) extends 
   override val hashId = 4100
   override val hashBaseId = 4100
   override def toString = {
-    "(%s %s (%s))".format(id.toString, typ.toString, Utils.join(terms.map("(" + _.toString + ")"), " "))
+    "(%s %s (%s))".format(id.toString, typ.toString, Utils.join(terms.map(_.toString), " "))
   }
   override val md5hashCode = computeMD5Hash(id, typ, terms)
 }

--- a/src/main/scala/uclid/smt/SynthLibInterface.scala
+++ b/src/main/scala/uclid/smt/SynthLibInterface.scala
@@ -71,9 +71,8 @@ class SynthLibInterface(args: List[String], sygusSyntax : Boolean, module: lang.
     out += cmd
   }
 
-  // TODO: change to grammar symbol
-  def generateGrammarDeclaration(gSym: lang.GrammarDecl): String = {
-    ""
+  def generateGrammarDeclaration(grammarSymbol: smt.GrammarSymbol): String = {
+    grammarSymbol.toString
   }
 
   def generateSynthDeclaration(sym: SynthSymbol) = {
@@ -86,9 +85,7 @@ class SynthLibInterface(args: List[String], sygusSyntax : Boolean, module: lang.
     var cmd = ""
 
     if (sygusSyntax) {
-      println("found grammar: " + module.grammarDecls.find(gDecl => !sym.gid.isEmpty && gDecl.id == sym.gid.get).toString())
-      val grammarDeclOpt = module.grammarDecls.find(gDecl => !sym.gid.isEmpty && gDecl.id == sym.gid.get)
-      val grammar = grammarDeclOpt.fold("")(generateGrammarDeclaration _)
+      val grammar = sym.grammar.fold("")(generateGrammarDeclaration _)
       cmd = "(synth-fun %s (%s) %s %s)\n".format(sym, sig, typeName, grammar)
     } else {
       cmd = "(synth-blocking-fun %s (%s) %s)\n".format(sym, sig, typeName)
@@ -144,8 +141,6 @@ class SynthLibInterface(args: List[String], sygusSyntax : Boolean, module: lang.
 
   override def checkSynth() : SolverResult = {
     val query = toString()
-    synthliblogger.debug("========= synthesis query =========\n" + query)
-    synthliblogger.debug("===================================")
     writeCommand(query)
     val ans = {
       readResponse() match {

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -256,6 +256,28 @@ class ParserSpec extends FlatSpec {
         assert (p.errors.exists(p => p._1.contains("Operator can only be used in a verification expression")))
     }
   }
+  "test-synthesis-grammar-0.ucl" should "parse successfully." in {
+      val fileModules = UclidMain.compile(List(new File("test/test-synthesis-grammar-0.ucl")), lang.Identifier("main"))
+      val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+      assert (instantiatedModules.size == 1)
+  }
+  "test-synthesis-grammar-1.ucl" should "parse successfully." in {
+      val fileModules = UclidMain.compile(List(new File("test/test-synthesis-grammar-1.ucl")), lang.Identifier("main"))
+      val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+      assert (instantiatedModules.size == 1)
+  }
+  "test-synthesis-grammar-2.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(List(new File("test/test-synthesis-grammar-2.ucl")), lang.Identifier("main"))
+      // should never get here.
+      assert (false);
+    }
+    catch {
+      // this list has all the errors from parsing
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size > 0)
+    }
+  }
   "test-typechecker-7.ucl" should "not parse successfully." in {
     try {
       val fileModules = UclidMain.compile(List(new File("test/test-typechecker-7.ucl")), lang.Identifier("main"))

--- a/test/test-synthesis-grammar-0.ucl
+++ b/test/test-synthesis-grammar-0.ucl
@@ -1,0 +1,33 @@
+/* Toy example #0 to test grammar with integers.
+   Run with `run -f -y "cvc4 --lang sygus2" test/test-synthesis-grammar-0.ucl`
+*/
+module main
+{
+  input a, b : integer;
+  var sum : integer;
+  var prev_sum : integer;
+  
+  grammar max_grammar (x : integer, y : integer) : integer = {
+    (start : integer) ::= 0 | 1 | x | y | 
+    					 (start + start) | (start - start) |
+    					 (if (cond) then start else start);
+    (cond : boolean) ::= true | false | (!cond) | (start <= start);
+  }
+
+  synthesis function max2 (x : integer, y : integer) : integer
+    grammar max_grammar(x, y);
+    //ensures (max2(x, y) >= x && max2(x, y) >= y);
+  
+
+  procedure max2_impl(x: integer, y: integer) returns (res: integer)
+    ensures (res >= x && res >= y);
+  {
+    res = max2(x ,y);
+  }
+
+  control {
+    vf = verify(max2_impl);
+    check;
+    print_results;
+  }
+}

--- a/test/test-synthesis-grammar-1.ucl
+++ b/test/test-synthesis-grammar-1.ucl
@@ -1,0 +1,31 @@
+/* Toy example #1 to test grammars with bitvectors.
+    Run with `run -f -y "cvc4 --lang sygus2" test/test-synthesis-grammar-1.ucl`
+*/
+module main
+{
+  grammar sign_grammar (x : bv64) : bv64 = {
+    (start : bv64) ::= 0bv64 | 1bv64 | x |
+    					 (start + start) | (start - start) |
+    					 (if (cond) then start else start);
+    (cond : boolean) ::= true | false | (!cond) | (start <= start);
+  }
+
+  synthesis function sign(x : bv64) : bv64
+    grammar sign_grammar(x, y);
+
+  procedure sign_impl(x: bv64) returns (res: bv64)
+    ensures (res == sign(x));
+  {
+    if (x > 0bv64) {
+        res = 1bv64;
+    } else {
+        res = 0bv64;
+    };
+  }
+
+  control {
+    vf = verify(sign_impl);
+    check;
+    print_results;
+  }
+}

--- a/test/test-synthesis-grammar-2.ucl
+++ b/test/test-synthesis-grammar-2.ucl
@@ -1,0 +1,34 @@
+/* Toy example #2 to test grammar with integers.
+   Run with `run -f -y "cvc4 --lang sygus2" test/test-synthesis-grammar-0.ucl`
+   This test should fail (no output type for grammar)
+*/
+module main
+{
+  input a, b : integer;
+  var sum : integer;
+  var prev_sum : integer;
+  
+  grammar max_grammar2 (x : integer, y : integer) : integer = {
+    (start : integer) ::= 0 | 1 | x | y | 
+    					 (start + start) | (start - start) |
+    					 (if (cond1) then start else start);
+    (cond : boolean) ::= true | false | (!cond) | (start <= start);
+  }
+
+  synthesis function max2 (x : integer, y : integer) : integer
+    grammar max_grammar(x, y);
+    //ensures (max2(x, y) >= x && max2(x, y) >= y);
+  
+
+  procedure max2_impl(x: integer, y: integer) returns (res: integer)
+    ensures (res >= x && res >= y);
+  {
+    res = max2(x ,y);
+  }
+
+  control {
+    vf = verify(max2_impl);
+    check;
+    print_results;
+  }
+}

--- a/test/test-synthesis-grammar-3.ucl
+++ b/test/test-synthesis-grammar-3.ucl
@@ -1,0 +1,34 @@
+/* Toy example #3 to test grammar with integers.
+    Run with `run -f -y "cvc4 --lang sygus2" test/test-synthesis-grammar-0.ucl`
+    This test should fail (type of cond should be boolean)
+*/
+module main
+{
+  input a, b : integer;
+  var sum : integer;
+  var prev_sum : integer;
+  
+  grammar max_grammar (x : integer, y : integer) : integer = {
+    (start : integer) ::= 0 | 1 | x | y | 
+    					 (start + start) | (start - start) |
+    					 (if (cond) then start else start);
+    (cond : integer) ::= true | false | (!cond) | (start <= start);
+  }
+
+  synthesis function max2 (x : integer, y : integer) : integer
+    grammar max_grammar(x, y);
+    //ensures (max2(x, y) >= x && max2(x, y) >= y);
+  
+
+  procedure max2_impl(x: integer, y: integer) returns (res: integer)
+    ensures (res >= x && res >= y);
+  {
+    res = max2(x ,y);
+  }
+
+  control {
+    vf = verify(max2_impl);
+    check;
+    print_results;
+  }
+}

--- a/test/test-synthesis-grammar-4.ucl
+++ b/test/test-synthesis-grammar-4.ucl
@@ -1,0 +1,34 @@
+/* Toy example #4 to test grammar with integers.
+    Run with `run -f -y "cvc4 --lang sygus2" test/test-synthesis-grammar-4.ucl`
+    This test should fail (type mismatch of grammar and function)
+*/
+module main
+{
+  input a, b : integer;
+  var sum : integer;
+  var prev_sum : integer;
+  
+  grammar max_grammar (x : integer, y : integer) : boolean = {
+    (start : integer) ::= 0 | 1 | x | y | 
+    					 (start + start) | (start - start) |
+    					 (if (cond) then start else start);
+    (cond : integer) ::= true | false | (!cond) | (start <= start);
+  }
+
+  synthesis function max2 (x : integer, y : integer) : integer
+    grammar max_grammar(x, y);
+    //ensures (max2(x, y) >= x && max2(x, y) >= y);
+  
+
+  procedure max2_impl(x: integer, y: integer) returns (res: integer)
+    ensures (res >= x && res >= y);
+  {
+    res = max2(x ,y);
+  }
+
+  control {
+    vf = verify(max2_impl);
+    check;
+    print_results;
+  }
+}


### PR DESCRIPTION
Initial implementation for grammar support in UCLID5 for the program synthesis using SyGuS 2.0.

Includes two example tests.

Implements BV and Int operators and uses a polymorphic operator rewriter for the grammar via a new pass called PolymorphicGrammarTypeRewriter.

Added a few TODOs in here.
1. Need to add support for interpreted definitions.
2. Create a new CI flow for synthesis.
3. Add type checker for grammars.