### PR TITLE
fix inline/noinline semantics

### DIFF
--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1445,10 +1445,19 @@ case class ProcedureDecl(
     Utils.join(body.toLines.map(PrettyPrinter.indent(2) + _), "\n")
   }
   override def declNames = List(id)
-  def hasPrePost = requires.size > 0 || ensures.size > 0
-  val shouldInline =
-    (annotations.ids.contains(Identifier("inline")) && !annotations.ids.contains(Identifier("noinline"))) ||
-    (ensures.size == 0)
+
+  lazy val shouldInline = {
+    if(annotations.ids.contains(Identifier("noinline")))
+    {
+      if(ensures.size == 0)
+        UclidMain.println("Warning: noinlining procedure "+ id + " even though it has no ensures statement")
+      if(annotations.ids.contains(Identifier("inline")))
+        throw new Utils.RuntimeError("Procedure " + id + " has both inline and noinline annotations.")
+      false;  
+    }
+    else
+      true;
+  }
 }
 case class TypeDecl(id: Identifier, typ: Type) extends Decl {
   override val hashId = 3903

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -101,7 +101,7 @@ class Z3Model(interface: Z3Interface, val model : z3.Model) extends Model {
 
       bottom = fint.getElse().toString
     } else {
-      return "ERROR " + e.toString + "\n"
+      return "UCLID is unable to convert this z3 array to string: " + e.toString + "\n"
     }
 
     array.foreach{ case (k, v) => {

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -225,9 +225,9 @@ class ProcedureVerifSpec extends FlatSpec {
   "test-procedure-noinline.ucl" should "verify all but 1 assertion successfully" in {
     VerifierSpec.expectedFails("./test/test-procedure-noinline.ucl", 1)
   }
-  // "test-procedure-noinline-2.ucl" should "fail" in {
-  //   VerifierSpec.expectedFails("./test/test-procedure-noinline-2.ucl", 1)
-  // }
+  "test-procedure-noinline-2.ucl" should "fail" in {
+    VerifierSpec.expectedFails("./test/test-procedure-noinline-2.ucl", 1)
+  }
   "test-procedure-checker-2.ucl" should "verify all but 4 invariants successfully." in {
     VerifierSpec.expectedFails("./test/test-procedure-checker-2.ucl", 4)
   }

--- a/test/test-instance-procedure-call-4.ucl
+++ b/test/test-instance-procedure-call-4.ucl
@@ -1,6 +1,6 @@
 module child
 {
-  procedure add(a : integer, b : integer) returns (c : integer)
+  procedure [noinline] add(a : integer, b : integer) returns (c : integer)
     requires (a >= 0 && a < 10);
     requires (b >= 0 && b < 10);
     ensures c == a + b;
@@ -16,7 +16,7 @@ module main
 
   instance chld : child();
 
-  procedure child_add(d : integer, e : integer) returns (f : integer)
+  procedure [noinline] child_add(d : integer, e : integer) returns (f : integer)
     requires (d >= 0 && d < 10);
     requires (e >= 0 && e < 10);
     ensures f == d + e;

--- a/test/test-old-instance-var-1.ucl
+++ b/test/test-old-instance-var-1.ucl
@@ -38,7 +38,7 @@ module main {
 
   instance cache : abstract_cache();
 
-  procedure havoc_cache_valid_map()
+  procedure [noinline] havoc_cache_valid_map()
     ensures (cache.cache_tag_map == old(cache.cache_tag_map));
     ensures (cache.cache_valid_map != old(cache.cache_valid_map));
     modifies cache;
@@ -46,7 +46,7 @@ module main {
     call cache.update_cache_valid_map();
   }
 
-  procedure havoc_cache_tag_map()
+  procedure [noinline] havoc_cache_tag_map()
     ensures (cache.cache_valid_map == old(cache.cache_valid_map));
     ensures (cache.cache_tag_map != old(cache.cache_tag_map));
     modifies cache;


### PR DESCRIPTION
The default is now to do what the [inline/noinline] directive says. If no directive is given, uclid will inline. If both directives are given for one procedure, uclid will noinline and print a warning.

Previous semantics:
![image](https://user-images.githubusercontent.com/17899331/92043735-7f1cdd80-ed31-11ea-94b0-c71f0b7757a6.png)

New semantics
![image](https://user-images.githubusercontent.com/17899331/92044069-4af5ec80-ed32-11ea-9480-f703a77d4baf.png)




