### PR TITLE
Remove instProcMap

### DIFF
--- a/src/main/scala/uclid/lang/ProcedureInliner.scala
+++ b/src/main/scala/uclid/lang/ProcedureInliner.scala
@@ -221,19 +221,6 @@ trait NewProcedureInlinerPass extends RewritePass {
     }
     BlockStmt(varsToDeclare, stmtsP)
   }
-
-/**
- * This procedure rewrites the module with additional annotations on 
- * the signatures of its procedure calls.
- *
- * @param module The module being analyzed
- * @param ctx The current scope
- */
-  override def rewriteModule(module : Module, ctx : Scope) : Option[Module] = {
-    val instProcMap = module.procedures.foldLeft(Map.empty[List[Identifier], ProcedureDecl])((acc, proc) => acc + (List(module.id, proc.id) -> proc))
-    val moduleP = module.withReplacedAnnotation[InstanceProcMapAnnotation](InstanceProcMapAnnotation(instProcMap))
-    Some(moduleP)
-  }
 }
 
 class NewInternalProcedureInlinerPass extends NewProcedureInlinerPass() {


### PR DESCRIPTION
These annotations don't appear to ever be used, and this appears to increase the size of the AST by 50%