### PR TITLE
use option to not get model from solver

### DIFF
--- a/src/main/scala/uclid/AssertionTree.scala
+++ b/src/main/scala/uclid/AssertionTree.scala
@@ -148,7 +148,7 @@ class AssertionTree {
     override val isAssert = false
   }
 
-  def _verify(node : TreeNode, solver : smt.Context, mode : VerifyMode) : List[CheckResult] = {
+  def _verify(node : TreeNode, solver : smt.Context, mode : VerifyMode, getModel : Boolean = true) : List[CheckResult] = {
     if (mode.isAssert) {
       solver.push()
       node.assumptions.foreach(a => solver.assert(a))
@@ -174,7 +174,7 @@ class AssertionTree {
           solver.assert(checkExpr)
           solver.curAssertName = e.name
           solver.curAssertLabel = e.label
-          val sat = solver.check()
+          val sat = solver.check(getModel)
           val result = sat.result match {
             case Some(true)  => smt.SolverResult(Some(false), sat.model)
             case Some(false) => smt.SolverResult(Some(true), sat.model)
@@ -201,9 +201,9 @@ class AssertionTree {
         List.empty
     }
   }
-  def verify(solver : smt.Context) : List[CheckResult] = {
-    _verify(root, solver, VerifyModePreprocess)
-    _verify(root, solver, VerifyModeAssert)
+  def verify(solver : smt.Context, getModel: Boolean=true) : List[CheckResult] = {
+    _verify(root, solver, VerifyModePreprocess, getModel)
+    _verify(root, solver, VerifyModeAssert, getModel)
   }
 
   def _printSMT(node : TreeNode, parentAssumptions : List[smt.Expr], label : Option[Identifier], solver : smt.SolverInterface) : List[String] = {

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -285,9 +285,10 @@ class SymbolicSimulator (module : Module) {
             }
             verifyProcedure(proc, label)
           case "check" => {
+            val getModel = module.cmds.contains("print_cex")
             lazySC match {
-              case None => proofResults = assertionTree.verify(solver)
-              case Some(lz) => proofResults = lz.assertionTree.verify(solver)
+              case None => proofResults = assertionTree.verify(solver, getModel)
+              case Some(lz) => proofResults = lz.assertionTree.verify(solver, getModel)
             }
             if (solver.filePrefix != "") {
               val smtOutput = solver.toString()

--- a/src/main/scala/uclid/smt/Context.scala
+++ b/src/main/scala/uclid/smt/Context.scala
@@ -205,7 +205,7 @@ abstract trait Context {
   def pop()
   def assert(e: Expr)
   def preassert(e: Expr)
-  def check() : SolverResult
+  def check(produceModel: Boolean = true) : SolverResult
   def checkSynth() : SolverResult
   def finish()
 

--- a/src/main/scala/uclid/smt/SMTLIB2Interface.scala
+++ b/src/main/scala/uclid/smt/SMTLIB2Interface.scala
@@ -412,7 +412,7 @@ class SMTLIB2Interface(args: List[String]) extends Context with SMTLIB2Base {
     }
   }
 
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     smtlibInterfaceLogger.debug("check")
     Utils.assert(solverProcess.isAlive(), "Solver process is not alive!")
     writeCommand("(check-sat)")
@@ -421,7 +421,7 @@ class SMTLIB2Interface(args: List[String]) extends Context with SMTLIB2Base {
         case Some(strP) =>
           val str = strP.stripLineEnd
           str match {
-            case "sat" => SolverResult(Some(true), getModel())
+            case "sat" => SolverResult(Some(true), if(produceModel) getModel() else None)
             case "unsat" => SolverResult(Some(false), None)
             case _ =>
               throw new Utils.AssertionError("Unexpected result from SMT solver: " + str.toString())

--- a/src/main/scala/uclid/smt/SynthLibInterface.scala
+++ b/src/main/scala/uclid/smt/SynthLibInterface.scala
@@ -126,7 +126,7 @@ class SynthLibInterface(args: List[String], sygusSyntax : Boolean) extends SMTLI
     astack = (smtlib2 :: astack.head) :: astack.tail
   }
 
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     synthliblogger.debug("check")
     // put in all the assertions as a conjunction
     total = "(and " + astack.foldLeft(""){ (acc, s) => acc + " " + s.mkString(" ")} + ")" :: total

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -490,7 +490,7 @@ class Z3Interface() extends Context {
 
   lazy val checkLogger = Logger("uclid.smt.Z3Interface.check")
   /** Check whether a particular expression is satisfiable.  */
-  override def check() : SolverResult = {
+  override def check(produceModel: Boolean = true) : SolverResult = {
     lazy val smtOutput = solver.toString()
     checkLogger.debug(smtOutput)
 
@@ -499,10 +499,13 @@ class Z3Interface() extends Context {
 
       val checkResult : SolverResult = z3Result match {
         case z3.Status.SATISFIABLE =>
-          val z3Model = solver.getModel()
           checkLogger.debug("SAT")
-          checkLogger.debug("Model: {}", z3Model.toString())
-          SolverResult(Some(true), Some(new Z3Model(this, z3Model)))
+          val model = if(produceModel) {
+            val z3Model = solver.getModel()
+            checkLogger.debug("Model: {}", z3Model.toString())
+            Some(new Z3Model(this, z3Model))
+          } else { None }
+          SolverResult(Some(true), model)
         case z3.Status.UNSATISFIABLE =>
           checkLogger.debug("UNSAT")
           SolverResult(Some(false), None)


### PR DESCRIPTION
No longer get model from solver unless print_cex is specified

Uses https://github.com/uclid-org/uclid/pull/18.