### PR TITLE
Add pass to remove procedures that are not verified

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -225,13 +225,15 @@ object UclidMain {
     passManager.addPass(new StatementScheduler())
     passManager.addPass(new BlockFlattener())
     passManager.addPass(new NewInternalProcedureInliner())
+    passManager.addPass(new VerifiedProceduresAnalysis())
+    passManager.addPass(new ModuleCleaner())
     passManager.addPass(new PrimedVariableCollector())
     passManager.addPass(new PrimedVariableEliminator())
     passManager.addPass(new PrimedHistoryRewriter())
     passManager.addPass(new IntroduceFreshHavocs())
     passManager.addPass(new RewriteFreshLiterals())
     passManager.addPass(new BlockFlattener())
-    passManager.addPass(new ModuleCleaner())
+    // passManager.addPass(new BlockFlattener())
     passManager.addPass(new BlockVariableRenamer())
     passManager
   }  

--- a/src/main/scala/uclid/lang/ModuleCleaner.scala
+++ b/src/main/scala/uclid/lang/ModuleCleaner.scala
@@ -1,7 +1,62 @@
 package uclid
 package lang
 
+import scala.collection.mutable
+
+/*
+ *  Collect verified procedures pass
+ * 
+ *  Author : Elizabeth Polgreen
+ *
+ * This pass collects a list of procedures which are verified using the verify(cmd)
+ * All other procedures can then be removed by the module cleaner pass, since the 
+ * all procedure calls have been inlined by the time this pass is run.
+ */
+   
+class CollectVerifiedProceduresPass extends ReadOnlyPass[Set[Identifier]]
+{
+  override def applyOnCmd(d: TraversalDirection.T, cmd: GenericProofCommand, in: Set[Identifier], context: Scope): Set[Identifier] = {
+    if(cmd.isVerify)
+    {
+      in + cmd.args(0)._1.asInstanceOf[Identifier];
+    }
+    else
+      in
+  }
+}
+
+class VerifiedProceduresAnalysis() extends ASTAnalyzer("VerifiedProceduresAnalysis", new CollectVerifiedProceduresPass()) {
+  override def reset() {
+    in = Some(Set[Identifier]())
+  }
+
+  override def visit(module : Module, context : Scope) : Option[Module] = {
+    val verifiedProcedureSet = visitModule(module, Set[Identifier](), context)
+    _out = Some(verifiedProcedureSet)
+    return Some(module)
+  }
+}
+
 class ModuleCleanerPass() extends RewritePass {
+  lazy val manager : PassManager = analysis.manager
+  
+  var doRemoveFunctions = false;
+  lazy val verifiedProcedureSet : Set[Identifier] = 
+  {
+    if(manager.doesPassExist("VerifiedProceduresAnalysis"))
+    {
+      val verifiedProcedureAnalysis = manager.pass("VerifiedProceduresAnalysis").asInstanceOf[VerifiedProceduresAnalysis]
+      doRemoveFunctions=true
+      verifiedProcedureAnalysis.out.getOrElse(Set[Identifier]())
+    }
+    else
+    {
+      Set[Identifier]()
+    }
+  }
+  
+  
+
   override def rewriteModuleTypesImport(modTypImport : ModuleTypesImportDecl, ctx : Scope) : Option[ModuleTypesImportDecl] = {
     None
   }
@@ -14,6 +69,14 @@ class ModuleCleanerPass() extends RewritePass {
   override def rewriteModuleDefinesImport(modDefImport : ModuleDefinesImportDecl, ctx : Scope) : Option[ModuleDefinesImportDecl] = {
     None
   }
+
+  override def rewriteProcedure(proc: ProcedureDecl, ctx: Scope): Option[ProcedureDecl] = {
+    if(verifiedProcedureSet.contains(proc.id) || !doRemoveFunctions)
+      Some(proc)
+    else
+      None    
+  }
+
   override def rewriteModule(module : Module, ctx : Scope) : Option[Module] = {
     val declsP = module.decls.sortWith((d1, d2) => d1.hashId < d2.hashId)
     Some(Module(module.id, declsP, module.cmds, module.notes))


### PR DESCRIPTION
This PR introduces a pass that collects a set of all procedures that are used as arguments to `verify(procedurename)` in the control block. The ModuleCleaner then removes all procedures that are not used as arguments to `verify(procedurename)`. 

This pass MUST be run after the procedureInliner. 

