### PR TITLE
add test for redundant assignment bug and temporarily disable the redundant assignment remover

### DIFF
--- a/src/main/scala/uclid/lang/StatementScheduler.scala
+++ b/src/main/scala/uclid/lang/StatementScheduler.scala
@@ -247,7 +247,17 @@ object StatementScheduler {
       case AssertStmt(e, _) => primeReadSet(e)
       case AssumeStmt(e, _) => primeReadSet(e)
       case HavocStmt(_) => Set.empty
-      case AssignStmt(_, rhss) => primeReadSets(rhss)
+      case AssignStmt(lhss, rhss) => 
+      // this code is not necessary because we do not support updating arrays using an array select e.g., A[i]' = 0
+      // but it is added here incase we do support this in future
+      {
+        val arrayIndices =
+        lhss flatMap {
+          case arrayselect : LhsArraySelect => Some(arrayselect.indices)
+          case _ => None
+        }
+        primeReadSets(rhss)++primeReadSets(arrayIndices.flatten)
+      }
       case BlockStmt(vars, stmts) =>
         val declaredVars : Set[Identifier] = vars.flatMap(vs => vs.ids.map(v => v)).toSet
         primeReadSets(stmts, context + vars) -- declaredVars

--- a/src/main/scala/uclid/lang/StatementScheduler.scala
+++ b/src/main/scala/uclid/lang/StatementScheduler.scala
@@ -185,7 +185,15 @@ object StatementScheduler {
       case AssertStmt(e, _) => readSet(e)
       case AssumeStmt(e, _) => readSet(e)
       case HavocStmt(_) => Set.empty
-      case AssignStmt(_, rhss) => readSets(rhss)
+      case AssignStmt(lhss, rhss) =>
+      {
+        val arrayIndices =
+        lhss flatMap {
+          case arrayselect : LhsArraySelect => Some(arrayselect.indices)
+          case _ => None
+        }
+        readSets(rhss)++readSets(arrayIndices.flatten)
+      }
       case BlockStmt(vars, stmts) =>
         val declaredVars : Set[Identifier] = vars.flatMap(vs => vs.ids.map(v => v)).toSet
         readSets(stmts, context + vars) -- declaredVars

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -434,6 +434,9 @@ class ModuleVerifSpec extends AnyFlatSpec {
   "issue-187b.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/issue-187b.ucl", 0)
   }
+  "test-redundant-assign.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-redundant-assign.ucl", 0)
+  }
 }
 class LTLVerifSpec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {

--- a/test/test-redundant-assign.ucl
+++ b/test/test-redundant-assign.ucl
@@ -1,0 +1,31 @@
+module main {
+
+    var index: integer;
+    var myArray: [integer]integer; 
+    
+    procedure shouldPass()
+    modifies myArray, index;
+    {       
+        index = 1;
+        myArray[index] = 0;
+        assert(myArray[1] == 0); // this assertion should pass
+    }
+
+    procedure shouldPass2()
+    modifies myArray, index;
+    {       
+        index = 1;
+        myArray[index] = 0;
+        assert(myArray[1] == 0); // this assertion should pass
+        index = 2;  // assignment should be ignored
+    }
+    
+
+    control {
+        v = verify(shouldPass);
+        v  = verify(shouldPass2);
+        check;
+        print_results;
+        v.print_cex(index);
+    }
+}


### PR DESCRIPTION
This exposes a bug where the redundant assignment removal was removing relevant assignments, e.g., in this example the redundant assignment eliminator is removing the first assignment to index which makes the subsequent assertion fail

~~~
    procedure shouldPass2()
    modifies myArray, index;
    {       
        index = 1; // this is being removed
        myArray[index] = 0;
        assert(myArray[1] == 0); // this assertion should pass
        index = 2;  // assignment should be ignored
    }
~~~

