### PR TITLE
output arity with sort in SMTlib

### DIFF
--- a/src/main/scala/uclid/smt/SMTLIB2Interface.scala
+++ b/src/main/scala/uclid/smt/SMTLIB2Interface.scala
@@ -139,7 +139,7 @@ trait SMTLIB2Base {
             (typeStr, newTypes)
           case UninterpretedType(typeName) => 
             // TODO: sorts with arity greater than 1? Does uclid allow such a thing?
-            val declDatatype = "(declare-sort %s)".format(typeName)
+            val declDatatype = "(declare-sort %s 0)".format(typeName)
             typeMap = typeMap.addSynonym(typeName, t)
             (typeName, List(declDatatype))
           case _ => 


### PR DESCRIPTION
currently has no test because cvc4 isn't tested with the smtlib interface