### PR TITLE
Testing: Check that imported defines give correct results

### DIFF
--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -679,12 +679,6 @@ class ParserSpec extends AnyFlatSpec {
     }
   }
 
-  "test-def-import-4.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-def-import-4.ucl")), lang.Identifier("main"))
-    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
-    assert (instantiatedModules.size == 1)
-  }
-
   "test-instance-procedure-call-6.ucl" should "not parse successfully" in {
     try {
       val fileModules = UclidMain.compile(List(new File("test/test-instance-procedure-call-6.ucl")), lang.Identifier("main"))

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -679,6 +679,12 @@ class ParserSpec extends AnyFlatSpec {
     }
   }
 
+  "test-def-import-4.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(List(new File("test/test-def-import-4.ucl")), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+
   "test-instance-procedure-call-6.ucl" should "not parse successfully" in {
     try {
       val fileModules = UclidMain.compile(List(new File("test/test-instance-procedure-call-6.ucl")), lang.Identifier("main"))

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -393,6 +393,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-def-import-0.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-def-import-0.ucl", 0)
   }
+  "test-def-import-4.ucl" should "verify all assertions." in {
+    SMTLIB2Spec.expectedFails("./test/test-def-import-4.ucl", 0)
+  }
   "test-procedure-postcondition-1.ucl" should "verify all but one assertion." in {
     SMTLIB2Spec.expectedFails("./test/test-procedure-postcondition-1.ucl", 1)
   }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -404,6 +404,9 @@ class ModuleVerifSpec extends AnyFlatSpec {
   "test-def-import-0.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-def-import-0.ucl", 0)
   }
+  "test-def-import-4.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-def-import-4.ucl", 0)
+  }
   "test-procedure-postcondition-1.ucl" should "verify all but one assertion." in {
     VerifierSpec.expectedFails("./test/test-procedure-postcondition-1.ucl", 1)
   }

--- a/test/test-def-import-4.ucl
+++ b/test/test-def-import-4.ucl
@@ -1,0 +1,21 @@
+module common {
+    define and (a, b : boolean) : boolean = a && b;
+}
+
+module main {
+    define * = common.*;
+
+    init {
+    }
+
+    next {
+    }
+
+    property p1 : (and(true, false) == false);
+    property p2 : (and(true, true) == true);
+
+    control {
+        check;
+        print_results;
+    }
+}

--- a/test/test-def-import-4.ucl
+++ b/test/test-def-import-4.ucl
@@ -15,6 +15,7 @@ module main {
     property p2 : (and(true, true) == true);
 
     control {
+        v = unroll(1);
         check;
         print_results;
     }


### PR DESCRIPTION
There are tests checking that imported defines compile, but I didn't see a test checking that the results of those imported defines were as they should be. Hence I'm adding this test.