### PR TITLE
temporarily disable multiple LTL properties

### DIFF
--- a/src/main/scala/uclid/lang/PropertyRewriter.scala
+++ b/src/main/scala/uclid/lang/PropertyRewriter.scala
@@ -409,7 +409,15 @@ class LTLPropertyRewriterPass extends RewritePass {
     if (ltlSpecs.size == 0) {
       Some(module)
     } else {
+      // throw errors if more than 1 LTL spec found
+      // TODO: this is a temporary fix for a known bug that occurs when conjoining an LTL specification with any other property
+      // where assumptions inserted into the module for the LTL property affect satisfiability of the other specifications
+      if(ltlSpecs.size > 1)
+        throw new Utils.RuntimeError(s"Modules containing more than 1 LTL specification are currently not supported. This support will be added in the next UCLID release.")
       val otherSpecs = moduleSpecs.filter(s => !s.params.exists(d => d == LTLExprDecorator))
+      if(otherSpecs.size > 0)
+        throw new Utils.RuntimeError(s"Modules containing at least 1 LTL specification combined with non-LTL specifications are not currently supported. This support will be added in the next UCLID release.")
+    
       Some(rewriteSpecs(module, ctx, ltlSpecs, otherSpecs))
     }
   }

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -131,9 +131,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-forloop-1.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-forloop-1.ucl", 0)
   }
-  "test-ite.ucl" should "verify all but 6 assertions successfully." in {
-    SMTLIB2Spec.expectedFails("./test/test-ite.ucl", 6)
-  }
+  // "test-ite.ucl" should "verify all but 6 assertions successfully." in {
+  //   SMTLIB2Spec.expectedFails("./test/test-ite.ucl", 6)
+  // }
   "test-bit-concat.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-bit-concat.ucl", 0)
   }
@@ -443,18 +443,18 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-history-1.ucl", 0)
   }
-  "test-ltl-0-safe.ucl" should "verify all assertions." in {
-    SMTLIB2Spec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
-  }
+  // "test-ltl-0-safe.ucl" should "verify all assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
+  // }
   "test-ltl-0-unsafe.ucl" should " fail to verify 2 assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-ltl-0-unsafe.ucl", 2)
   }
-  "test-ltl-1-safe.ucl" should "verify all assertions." in {
-    SMTLIB2Spec.expectedFails("./test/test-ltl-1-safe.ucl", 0)
-  }
-  "test-ltl-1-unsafe.ucl" should "fail to verify 10 assertions." in {
-    SMTLIB2Spec.expectedFails("./test/test-ltl-1-unsafe.ucl", 10)
-  }
+  // "test-ltl-1-safe.ucl" should "verify all assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/test-ltl-1-safe.ucl", 0)
+  // }
+  // "test-ltl-1-unsafe.ucl" should "fail to verify 10 assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/test-ltl-1-unsafe.ucl", 10)
+  // }
   "test-ltl-2-holds.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-ltl-2-holds.ucl", 0)
   }
@@ -479,9 +479,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-ltl-5-fails.ucl" should "fail to verify 2 assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-ltl-5-fails.ucl", 2)
   }
-  "test-ltl-6-fails.ucl" should "fail to verify 4 assertions." in {
-    SMTLIB2Spec.expectedFails("./test/test-ltl-6-fails.ucl", 4)
-  }
+  // "test-ltl-6-fails.ucl" should "fail to verify 4 assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/test-ltl-6-fails.ucl", 4)
+  // }
   "test-ltl-7-holds.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-ltl-7-holds.ucl", 0)
   }
@@ -491,12 +491,12 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-ltl-7b-fails.ucl" should "fail to verify 5 assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-ltl-7b-fails.ucl", 5)
   }
-  "queue-ltl.ucl" should "verify all assertions." in {
-    SMTLIB2Spec.expectedFails("./test/queue-ltl.ucl", 0)
-  }
-  "ltl-eventually-1.ucl" should "fail to verify 3 assertions." in {
-    SMTLIB2Spec.expectedFails("./test/ltl-eventually-1.ucl", 3)
-  }
+  // "queue-ltl.ucl" should "verify all assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/queue-ltl.ucl", 0)
+  // }
+  // "ltl-eventually-1.ucl" should "fail to verify 3 assertions." in {
+  //   SMTLIB2Spec.expectedFails("./test/ltl-eventually-1.ucl", 3)
+  // }
   "ltl-toy-0.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/ltl-toy-0.ucl", 0)
   }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -133,9 +133,9 @@ class BasicVerifierSpec extends AnyFlatSpec {
   "test-forloop-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-forloop-1.ucl", 0)
   }
-  "test-ite.ucl" should "verify all but 6 assertions successfully." in {
-    VerifierSpec.expectedFails("./test/test-ite.ucl", 6)
-  }
+  // "test-ite.ucl" should "verify all but 6 assertions successfully." in {
+  //   VerifierSpec.expectedFails("./test/test-ite.ucl", 6)
+  // }
   "test-bit-concat.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-bit-concat.ucl", 0)
   }
@@ -454,18 +454,18 @@ class LTLVerifSpec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-history-1.ucl", 0)
   }
-  "test-ltl-0-safe.ucl" should "verify all assertions." in {
-    VerifierSpec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
-  }
+  // "test-ltl-0-safe.ucl" should "verify all assertions." in {
+  //   VerifierSpec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
+  // }
   "test-ltl-0-unsafe.ucl" should " fail to verify 2 assertions." in {
     VerifierSpec.expectedFails("./test/test-ltl-0-unsafe.ucl", 2)
   }
-  "test-ltl-1-safe.ucl" should "verify all assertions." in {
-    VerifierSpec.expectedFails("./test/test-ltl-1-safe.ucl", 0)
-  }
-  "test-ltl-1-unsafe.ucl" should "fail to verify 10 assertions." in {
-    VerifierSpec.expectedFails("./test/test-ltl-1-unsafe.ucl", 10)
-  }
+  // "test-ltl-1-safe.ucl" should "verify all assertions." in {
+  //   VerifierSpec.expectedFails("./test/test-ltl-1-safe.ucl", 0)
+  // }
+  // "test-ltl-1-unsafe.ucl" should "fail to verify 10 assertions." in {
+  //   VerifierSpec.expectedFails("./test/test-ltl-1-unsafe.ucl", 10)
+  // }
   "test-ltl-2-holds.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-ltl-2-holds.ucl", 0)
   }
@@ -490,9 +490,9 @@ class LTLVerifSpec extends AnyFlatSpec {
   "test-ltl-5-fails.ucl" should "fail to verify 2 assertions." in {
     VerifierSpec.expectedFails("./test/test-ltl-5-fails.ucl", 2)
   }
-  "test-ltl-6-fails.ucl" should "fail to verify 4 assertions." in {
-    VerifierSpec.expectedFails("./test/test-ltl-6-fails.ucl", 4)
-  }
+  // "test-ltl-6-fails.ucl" should "fail to verify 4 assertions." in {
+  //   VerifierSpec.expectedFails("./test/test-ltl-6-fails.ucl", 4)
+  // }
   "test-ltl-7-holds.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-ltl-7-holds.ucl", 0)
   }
@@ -502,12 +502,12 @@ class LTLVerifSpec extends AnyFlatSpec {
   "test-ltl-7b-fails.ucl" should "fail to verify 5 assertions." in {
     VerifierSpec.expectedFails("./test/test-ltl-7b-fails.ucl", 5)
   }
-  "queue-ltl.ucl" should "verify all assertions." in {
-    VerifierSpec.expectedFails("./test/queue-ltl.ucl", 0)
-  }
-  "ltl-eventually-1.ucl" should "fail to verify 3 assertions." in {
-    VerifierSpec.expectedFails("./test/ltl-eventually-1.ucl", 3)
-  }
+  // "queue-ltl.ucl" should "verify all assertions." in {
+  //   VerifierSpec.expectedFails("./test/queue-ltl.ucl", 0)
+  // }
+  // "ltl-eventually-1.ucl" should "fail to verify 3 assertions." in {
+  //   VerifierSpec.expectedFails("./test/ltl-eventually-1.ucl", 3)
+  // }
   "ltl-toy-0.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/ltl-toy-0.ucl", 0)
   }


### PR DESCRIPTION
Combining multiple LTL properties can result in unsound results because the assumptions introduced by each LTL property into the module may affect verification of other properties.

I've temporarily disabled using multiple LTL properties until we can fix this. 