### PR TITLE
temporary fix for hashing for synthesis function

### DIFF
--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -845,7 +845,7 @@ case class AssignmentModel(functions : List[Expr]) extends Hashable {
 case class SynthSymbol(id: String, symbolTyp: lang.FunctionSig, gid: Option[Identifier], gargs: List[Identifier], conds : List[lang.Expr]) extends Expr (smt.Converter.typeToSMT(symbolTyp.typ)) {
   override val hashId = mix(id.hashCode(), mix(symbolTyp.typ.hashCode(), 315))
   override val hashCode = computeHash
-  override val md5hashCode = computeMD5Hash(id, symbolTyp.typ)
+  override val md5hashCode = computeMD5Hash(id)
   override def toString = id.toString
 }
 case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) extends Expr (symbolTyp) {


### PR DESCRIPTION
Fix needed because symbolTyp.typ can no longer be hashed, after commit 27bcb7e2212b15b2f45ba1cba482c65b642f50a3.
A better fix is to separate UclidLang and SMTLang completely so SynthSymbol no longer needs lang.FunctionSig.