### PR TITLE
[Modifies Set] Implemented modifies set inference.

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -74,12 +74,13 @@ object UclidMain {
       smtFileGeneration: String = "",
       sygusFormat: Boolean = false,
       enumToNumeric: Boolean = false,
+      modSetAnalysis: Boolean = false,
       ufToArray: Boolean = false,
       printStackTrace: Boolean = false,
       verbose : Int = 0,
       files : Seq[java.io.File] = Seq(),
       testFixedpoint: Boolean = false
-  )
+  ) 
 
   def parseOptions(args: Array[String]) : Option[Config] = {
     val parser = new scopt.OptionParser[Config]("uclid") {
@@ -113,6 +114,10 @@ object UclidMain {
         (_, c) => c.copy(enumToNumeric = true)
       }.text("Enable conversion from EnumType to NumericType - KNOWN BUGS.")
 
+      opt[Unit]('M', "mod-set-analysis").action{
+        (_, c) => c.copy(modSetAnalysis = true)
+      }.text("Infers modifies set automatically.")
+
       opt[Unit]('u', "uf-to-array").action{
         (_, c) => c.copy(ufToArray = true)
       }.text("Enable conversion from Uninterpreted Functions to Arrays.")
@@ -141,7 +146,7 @@ object UclidMain {
         return
       }
       val mainModuleName = Identifier(config.mainModuleName)
-      val modules = compile(config.files, mainModuleName)
+      val modules = compile(config, mainModuleName)
       val mainModule = instantiate(config, modules, mainModuleName, true)
       mainModule match {
         case Some(m) => execute(m, config)
@@ -184,7 +189,7 @@ object UclidMain {
     }
   }
 
-  def createCompilePassManager(test: Boolean, mainModuleName: lang.Identifier) = {
+  def createCompilePassManager(config: Config, test: Boolean, mainModuleName: lang.Identifier) = {
     val passManager = new PassManager("compile")
     // adds init and next to every module
     passManager.addPass(new ModuleCanonicalizer())
@@ -198,6 +203,11 @@ object UclidMain {
     passManager.addPass(new ModuleConstantsImportRewriter())
     // imports uninterpreted functions
     passManager.addPass(new ModuleFunctionsImportRewriter())
+    // automatically compute modifies set
+    if (config.modSetAnalysis) {
+        passManager.addPass(new ModSetAnalysis())
+        passManager.addPass(new ModSetRewriter())
+    }
     // collects external types to the current module (e.g., module.mytype)
     passManager.addPass(new ExternalTypeAnalysis())
     // replaces module.mytype with external type 
@@ -276,10 +286,11 @@ object UclidMain {
     passManager
   }  
   /** Parse modules, typecheck them, inline procedures, create LTL monitors, etc. */
-  def compile(srcFiles : Seq[java.io.File], mainModuleName : Identifier, test : Boolean = false): List[Module] = {
+  def compile(config: Config, mainModuleName : Identifier, test : Boolean = false): List[Module] = {
     type NameCountMap = Map[Identifier, Int]
+    val srcFiles : Seq[java.io.File] = config.files
     var nameCnt : NameCountMap = Map().withDefaultValue(0)
-    val passManager = createCompilePassManager(test, mainModuleName)
+    val passManager = createCompilePassManager(config, test, mainModuleName)
 
     val filenameAdderPass = new AddFilenameRewriter(None)
     // Helper function to parse a single file.

--- a/src/main/scala/uclid/lang/ModSetAnalysis.scala
+++ b/src/main/scala/uclid/lang/ModSetAnalysis.scala
@@ -1,0 +1,127 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2017.
+ * Sanjit A. Seshia, Rohit Sinha and Pramod Subramanyan.
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author : Kevin Cheang
+ *
+ * The ModSetAnalysisPass collects all the mod sets for procedures
+ *
+ */
+package uclid
+package lang
+
+class ModSetAnalysisPass() extends ReadOnlyPass[Map[Identifier, Set[Identifier]]] {
+  // Map from procedure id to its inferred modifies set
+  type T = Map[Identifier, Set[Identifier]]
+
+  /** Recursively computes the modifies set for a statement by looking at the
+   *  left hand side assignments and havoc statements.
+   *
+   *  @param stmt The statement to infer
+   *  @param varIdSet A Set of state variables to include in the modifies set.
+   *                  This is usually the set of output and state variables.
+   */
+  def collectStatementModifies(stmt: Statement, varIdSet: Set[Identifier]): Set[Identifier] = {
+    stmt match {
+        case HavocStmt(havocableEntity) => {
+            havocableEntity match {
+                case HavocableId(id) => if (varIdSet.contains(id)) Set(id) else Set.empty
+                case _ => Set.empty
+            }
+        }
+        case AssignStmt(lhss, _) => lhss.map(lhs => lhs.ident).filter(ident => varIdSet.contains(ident)).foldLeft(List.empty[Identifier])((acc, ident) => ident :: acc).toSet
+        case BlockStmt(_, stmts) => stmts.foldLeft(Set.empty[Identifier])((acc, stmt) => acc ++ collectStatementModifies(stmt, varIdSet))
+        case IfElseStmt(_, thn, els) => collectStatementModifies(thn, varIdSet) ++ collectStatementModifies(els, varIdSet)
+        case ForStmt(_, _, _, body) => collectStatementModifies(body, varIdSet)
+        case WhileStmt(_, body, _) => collectStatementModifies(body, varIdSet)
+        case CaseStmt(body) => body.map(pair => collectStatementModifies(pair._2, varIdSet)).flatten.toSet
+        case ProcedureCallStmt(_, lhss, _, _, _) => lhss.map(lhs => lhs.ident).filter(varIdSet.contains(_)).foldLeft(List.empty[Identifier])((acc, ident) => ident :: acc).toSet
+        case _ => Set.empty
+    }
+  }
+
+  override def applyOnProcedure(d : TraversalDirection.T, proc : ProcedureDecl, in : T, context : Scope) : T = {
+    val stateVarIds = context.vars.map(v => v.varId)
+    val outputVarIds = context.outputs.map(v => v.outId)
+    val varIdSet = stateVarIds ++ outputVarIds
+    val modSet = collectStatementModifies(proc.body, varIdSet)
+    in + (proc.id -> modSet)
+  }
+}
+
+class ModSetAnalysis() extends ASTAnalyzer("ModSetAnalysis", new ModSetAnalysisPass()) {
+  override def reset() {
+    in = Some(Map.empty[Identifier, Set[Identifier]])
+  }
+
+  /** Visit the module and infer the writesets using the left hand side assignments and havocs.
+   *  Also updates the output to be a map from the procedure id to the inferred modifies set.
+   */
+  override def visit(module : Module, context : Scope) : Option[Module] = {
+    val modSetMap = visitModule(module, Map.empty[Identifier, Set[Identifier]], context)
+    _out = Some(modSetMap)
+    return Some(module)
+  }
+}
+
+class ModSetRewriterPass() extends RewritePass {
+    /** Rewrites the modifies set to contain all left hand side and havoced variables
+        including the ones nested in procedure calls.
+        NOTE: This does not overwrite the entire modifies set! It adds the inferred
+        set to the current modifies set if any exists.
+     */
+    override def rewriteProcedure(proc : ProcedureDecl, ctx : Scope) : Option[ProcedureDecl] = {
+        val modSetMap = analysis.manager.pass("ModSetAnalysis").asInstanceOf[ModSetAnalysis].out.get
+        val inferredModSet = modSetMap.get(proc.id) match {
+            case Some(set) => set.map(ident => ModifiableId(ident))
+            case None => Set.empty[ModifiableEntity]
+        }
+        val calleeModSets = proc.body match {
+            case BlockStmt(_, stmts) => {
+                stmts.filter(stmt => stmt.isInstanceOf[ProcedureCallStmt])
+                     .map(stmt => modSetMap.get(stmt.asInstanceOf[ProcedureCallStmt].id) match {
+                        case Some(set) => set.map(ident => ModifiableId(ident)).toList
+                        case None => List.empty[ModifiableEntity]
+                     }).flatten.toSet
+            }
+            case _ => Set.empty
+        }
+        val modSet = proc.modifies
+        // combined modifies set containing the original modifies set, inferred modifies set, and modifies set of the callees
+        val combinedModSet = modSet ++ inferredModSet ++ calleeModSets
+        Some(ProcedureDecl(proc.id, proc.sig, proc.body, proc.requires, proc.ensures, combinedModSet, proc.annotations))
+    }
+}
+
+class ModSetRewriter() extends ASTRewriter("ModSetRewriter", new ModSetRewriterPass()) {
+	override val repeatUntilNoChange = true
+}

--- a/src/main/scala/uclid/lang/ModSetAnalysis.scala
+++ b/src/main/scala/uclid/lang/ModSetAnalysis.scala
@@ -64,7 +64,15 @@ class ModSetAnalysisPass() extends ReadOnlyPass[Map[Identifier, Set[Identifier]]
         case ForStmt(_, _, _, body) => collectStatementModifies(body, varIdSet)
         case WhileStmt(_, body, _) => collectStatementModifies(body, varIdSet)
         case CaseStmt(body) => body.map(pair => collectStatementModifies(pair._2, varIdSet)).flatten.toSet
-        case ProcedureCallStmt(_, lhss, _, _, _) => lhss.map(lhs => lhs.ident).filter(varIdSet.contains(_)).foldLeft(List.empty[Identifier])((acc, ident) => ident :: acc).toSet
+        case ProcedureCallStmt(id, lhss, _, instanceId, _) => {
+          if (instanceId.isDefined) {
+            throw new Utils.UnimplementedException("Modifies set analysis is unimplemented for instance procedure calls.");
+          }
+          lhss.map(lhs => lhs.ident)
+              .filter(varIdSet.contains(_))
+              .foldLeft(List.empty[Identifier])((acc, ident) => ident :: acc)
+              .toSet
+        }
         case _ => Set.empty
     }
   }

--- a/src/test/scala/ModularProductSpec.scala
+++ b/src/test/scala/ModularProductSpec.scala
@@ -49,7 +49,7 @@ object ModularProductHelperSpec {
         UclidMain.enableStringOutput()
         UclidMain.clearStringOutput()
         val config = UclidMain.Config() 
-        val modules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"), true)
+        val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
         val mainModule = UclidMain.instantiate(config, modules, l.Identifier("main"), false)
         assert (mainModule.isDefined)
         val results = UclidMain.execute(mainModule.get, config)
@@ -63,7 +63,7 @@ object ModularProductHelperSpec {
 class ModularProductSpec extends AnyFlatSpec {
 
     "test-modularproduct-1.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-1.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-1.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
@@ -71,7 +71,7 @@ class ModularProductSpec extends AnyFlatSpec {
     "test-modularproduct-2-fails.ucl" should "not parse successfully." in {
         try {
         val filename = "test/test-modularproduct-2-fails.ucl"
-        val fileModules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
         assert (fileModules.size == 1)
         }
         catch {
@@ -81,49 +81,49 @@ class ModularProductSpec extends AnyFlatSpec {
     }
 
     "test-modularproduct-3.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-3.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-3.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-4.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-4.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-4.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-5.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-5.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-5.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-6.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-6.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-6.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-7.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-7.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-7.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-8.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-8.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-8.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-9.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-9.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-9.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-10.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-10.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-10.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
@@ -131,7 +131,7 @@ class ModularProductSpec extends AnyFlatSpec {
     "test-modularproduct-11-fails.ucl" should "not parse successfully." in {
         try {
         val filename = "test/test-modularproduct-11-fails.ucl"
-        val fileModules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
         assert (fileModules.size == 1)
         }
         catch {
@@ -141,37 +141,37 @@ class ModularProductSpec extends AnyFlatSpec {
     }
 
     "test-modularproduct-12.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-12.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-12.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-13.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-13.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-13.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-14.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-14.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-14.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-15.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-15.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-15.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-16.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-16.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-16.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
 
     "test-modularproduct-17.ucl" should "parse successfully." in {
-        val fileModules = UclidMain.compile(List(new File("test/test-modularproduct-17.ucl")), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modularproduct-17.ucl"), lang.Identifier("main"))
         val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
         assert (instantiatedModules.size == 1);
     }
@@ -191,7 +191,7 @@ class ModularProductSpec extends AnyFlatSpec {
     "test-modularproduct-21-fails.ucl" should "not parse successfully" in {
         try {
         val filename = "test/test-modularproduct-21-fails.ucl"
-        val fileModules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
         assert (fileModules.size == 1)
         }
         catch {
@@ -203,7 +203,7 @@ class ModularProductSpec extends AnyFlatSpec {
     "test-modularproduct-22-fails.ucl" should "not parse successfully" in {
         try {
         val filename = "test/test-modularproduct-22-fails.ucl"
-        val fileModules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"))
+        val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
         assert (fileModules.size == 1)
         }
         catch {

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -48,7 +48,7 @@ class ParserSpec extends AnyFlatSpec {
   "test-type1.ucl" should "not parse successfully." in {
     try {
       val filename = "test/test-type1.ucl"
-      val fileModules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
       assert (fileModules.size == 2)
     }
     catch {
@@ -59,7 +59,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-0.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-0.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-0.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -70,7 +70,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-1.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -83,7 +83,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-module-errors.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-module-errors.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-module-errors.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -94,7 +94,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-6.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-6.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-6.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -105,7 +105,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-3.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-3.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-3.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -117,7 +117,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-4.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-4.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-4.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -129,7 +129,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-recursion.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-recursion.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-recursion.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -142,7 +142,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-recursion-2.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-recursion-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-recursion-2.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -155,7 +155,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-procedure-types-errors.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-procedure-types-errors.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-types-errors.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -168,7 +168,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-procedure-invocation-errors.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-procedure-invocation-errors.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-invocation-errors.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -181,7 +181,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-syntax-errors-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-syntax-errors-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-syntax-errors-1.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -194,7 +194,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-5.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-5.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-5.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -206,7 +206,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-modules-2.ucl" should "not parse successfully." in {
     try {
-     val fileModules = UclidMain.compile(List(new File("test/test-modules-2.ucl")), lang.Identifier("main"))
+     val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modules-2.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -218,7 +218,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-procedure-checker-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-procedure-checker-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-checker-1.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -230,9 +230,29 @@ class ParserSpec extends AnyFlatSpec {
         assert (p.errors.exists(p => p._1.contains("Identifier cannot be declared modifiable: z")))
     }
   }
+  "test-mod-set-analysis-0.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-0.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-mod-set-analysis-1.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-1.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-mod-set-analysis-2.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-2.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-mod-set-analysis-3.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-3.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
   "test-mutual-recursion-error.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-mutual-recursion-error.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-mutual-recursion-error.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -245,7 +265,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-parsing-history-op-error.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-parsing-history-op-error.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-parsing-history-op-error.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -258,7 +278,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-7.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-7.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-7.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -271,7 +291,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-typechecker-8.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-typechecker-8.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-typechecker-8.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -284,7 +304,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-types-import-redecl.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-types-import-redecl.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-types-import-redecl.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -299,23 +319,23 @@ class ParserSpec extends AnyFlatSpec {
     }
   }
   "test-define-expand.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-define-expand.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-define-expand.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-procedure-inline-bv.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-procedure-inline-bv.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-inline-bv.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-procedure-postcondition-2.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-procedure-postcondition-2.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-postcondition-2.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-define-recursive.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-define-recursive.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-define-recursive.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }
@@ -327,38 +347,38 @@ class ParserSpec extends AnyFlatSpec {
     }
   }
   "nested_instances.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/nested_instances.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/nested_instances.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-nested-modules-1.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-nested-modules-1.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-nested-modules-1.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-nested-modules-2.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-nested-modules-2.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-nested-modules-2.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-block-var-0.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-block-var-0.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-block-var-0.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-modules-7.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-modules-7.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modules-7.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-block-var-renaming-1.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-block-var-renaming-1.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-block-var-renaming-1.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "test-multiple-writes.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-multiple-writes.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-multiple-writes.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -368,7 +388,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-cyclic-deps.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-cyclic-deps.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-cyclic-deps.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -378,7 +398,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-procedure-next.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-procedure-next.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-procedure-next.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -388,7 +408,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-modules-3.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-modules-3.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modules-3.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -398,7 +418,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-modules-4.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-modules-4.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modules-4.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -409,7 +429,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-primed-variables-2.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-primed-variables-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-primed-variables-2.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -419,7 +439,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-forloop-error-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-forloop-error-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-forloop-error-1.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -429,7 +449,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-string-0.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-string-0.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-string-0.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -439,7 +459,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-string-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-string-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-string-1.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserError =>
@@ -448,7 +468,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-parser-nested-next-block.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-parser-nested-next-block.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-parser-nested-next-block.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -457,7 +477,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "array-update-2.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/array-update-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/array-update-2.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -467,7 +487,7 @@ class ParserSpec extends AnyFlatSpec {
   "test-string-2.ucl" should "parse successfully." in {
     UclidMain.enableStringOutput()
     UclidMain.clearStringOutput()
-    val fileModules = UclidMain.compile(List(new File("test/test-string-2.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-string-2.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     val results = UclidMain.execute(instantiatedModules(0), UclidMain.Config())
     val stringOutput = UclidMain.stringOutput.toString().trim()
@@ -476,43 +496,43 @@ class ParserSpec extends AnyFlatSpec {
   }
 
   "test-hyperproperty-0.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-0.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-0.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "longcomment.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/longcomment.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/longcomment.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "test-array-record.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-array-record.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-array-record.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "test-array-record-1.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-array-record-1.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-array-record-1.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "recorderror.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/recorderror.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/recorderror.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
   "inputerror.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/inputerror.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/inputerror.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "test-hyperproperty-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-1.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -524,7 +544,7 @@ class ParserSpec extends AnyFlatSpec {
 
   // "test-hyperproperty-2.ucl" should "not parse successfully." in {
   //   try {
-  //     val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-2.ucl")), lang.Identifier("main"))
+  //     val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-2.ucl"), lang.Identifier("main"))
   //     assert (false)
   //   } catch {
   //     case p : Utils.ParserErrorList =>
@@ -532,18 +552,18 @@ class ParserSpec extends AnyFlatSpec {
   //   }
   // }
   "test-modify-instance.ucl" should "should parse successfully." in {
-      val fileModules = UclidMain.compile(List(new File("test/test-modify-instance.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-modify-instance.ucl"), lang.Identifier("main"))
       val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
       assert (instantiatedModules.size == 1)
   }
   "test-hyperproperty-2.ucl" should "should parse successfully." in {
-      val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-2.ucl"), lang.Identifier("main"))
       val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
       assert (instantiatedModules.size == 1)
   }
   "test-hyperproperty-3.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-3.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-3.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -553,7 +573,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "proc_requires_3.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/proc_requires_3.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/proc_requires_3.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -562,26 +582,26 @@ class ParserSpec extends AnyFlatSpec {
     }
   }
   "test-expression-suffix-function.ucl" should "parse successfully" in {
-    val fileModules = UclidMain.compile(List(new File("test/test-expression-suffix-function.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-expression-suffix-function.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1);
   }
 
   "test-unsigned-comparators-0.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-unsigned-comparators-0.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-unsigned-comparators-0.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1);
   }
 
   "test-extid-axiom.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-extid-axiom.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-extid-axiom.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1);
   }
 
   "test-hyperproperty-5.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-hyperproperty-5.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-hyperproperty-5.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -591,7 +611,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "syntax-error-input-assign-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/syntax-error-input-assign-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/syntax-error-input-assign-1.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -601,7 +621,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "syntax-error-input-assign-2.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/syntax-error-input-assign-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/syntax-error-input-assign-2.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -611,7 +631,7 @@ class ParserSpec extends AnyFlatSpec {
   
   "test-func-import-5.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-func-import-5.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-func-import-5.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case e : Utils.ParserError => assert(e.msg.contains("Redeclaration error"))
@@ -620,7 +640,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-func-import-6.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-func-import-6.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-func-import-6.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case e : Utils.ParserError  => assert(e.msg.contains("Trying to import from a module that does not"))
@@ -629,7 +649,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-func-import-7.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-func-import-7.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-func-import-7.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
         case e : Utils.ParserError => assert(e.msg.contains("Trying to import from the same module"))
@@ -638,7 +658,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-const-import-5.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-const-import-5.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-import-5.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case e : Utils.ParserError => assert(e.msg.contains("Trying to import from a module that does not"))
@@ -647,7 +667,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-const-import-6.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-const-import-6.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-import-6.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case e : Utils.ParserError => assert(e.msg.contains("Trying to import from the same module"))
@@ -655,14 +675,14 @@ class ParserSpec extends AnyFlatSpec {
   }
 
   "test-def-import-0.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-def-import-0.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-def-import-0.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "test-def-import-1.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-def-import-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-def-import-1.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -672,7 +692,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-def-import-2.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-def-import-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-def-import-2.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case e : Utils.ParserError => assert(e.msg.contains("Trying to import from a module that does not"))
@@ -681,7 +701,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-instance-procedure-call-6.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-instance-procedure-call-6.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-instance-procedure-call-6.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserErrorList =>
@@ -690,20 +710,20 @@ class ParserSpec extends AnyFlatSpec {
   }
 
   "test-instance-procedure-call-2.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/test-instance-procedure-call-2.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-instance-procedure-call-2.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "issue-187a.ucl" should "parse successfully." in {
-    val fileModules = UclidMain.compile(List(new File("test/issue-187a.ucl")), lang.Identifier("main"))
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/issue-187a.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
 
   "test-invalid-cmd-param.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-invalid-cmd-param.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-invalid-cmd-param.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserError => assert (true)
@@ -713,7 +733,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-invalid-cmd-param-2.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-invalid-cmd-param-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-invalid-cmd-param-2.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserError => assert (true)
@@ -723,7 +743,7 @@ class ParserSpec extends AnyFlatSpec {
 
   "test-invalid-verif-var.ucl" should "not parse successfully" in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-invalid-verif-var.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-invalid-verif-var.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
       case p : Utils.ParserError => assert (true)

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -49,7 +49,7 @@ object SMTLIB2Spec {
     UclidMain.enableStringOutput()
     UclidMain.clearStringOutput()
     val config = UclidMain.Config().copy(smtSolver=List("z3", "-smt2", "-in"))
-    val modules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"), true)
+    val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
     val mainModule = UclidMain.instantiate(config, modules, l.Identifier("main"), false)
     assert (mainModule.isDefined)
     val results = UclidMain.execute(mainModule.get, config)

--- a/src/test/scala/Utils.scala
+++ b/src/test/scala/Utils.scala
@@ -1,0 +1,23 @@
+package uclid
+package test
+
+import java.io.File
+
+package object ConfigCons {
+  /** Helper that returns a Config with the given filename.
+   *
+   *  @param filename The name of the file being tested in the Config.
+   */
+  def createConfig(filename: String): UclidMain.Config = {
+    UclidMain.Config(files=List(new File(filename)))
+  }
+
+  /** Helper that returns a Config with the given filename 
+   *  and with modSetAnalysis option on.
+   *
+   *  @param filename The name of the file being tested in the Config.
+   */
+  def createConfigWithMSA(filename: String): UclidMain.Config = {
+  	UclidMain.Config(files=List(new File(filename)), modSetAnalysis=true)
+  }
+}

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -45,15 +45,16 @@ import java.io.File
 import uclid.{lang => l}
 
 object VerifierSpec {
-  def expectedFails(filename: String, nFail : Int) : String = {
+  def expectedFails(filename: String, nFail : Int, config: Option[UclidMain.Config]=None) : String = {
     UclidMain.enableStringOutput()
     UclidMain.clearStringOutput()
-    val config = UclidMain.Config() 
-    val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
-    val mainModule = UclidMain.instantiate(config, modules, l.Identifier("main"), false)
+    val compileConfig = if (config.isDefined) config.get else ConfigCons.createConfig(filename)
+    val modules = UclidMain.compile(compileConfig, lang.Identifier("main"), true)
+    val instantiateConfig = UclidMain.Config() 
+    val mainModule = UclidMain.instantiate(instantiateConfig, modules, l.Identifier("main"), false)
     assert (mainModule.isDefined)
     // val config = UclidMain.Config("main", List("/usr/bin/z3", "-in", "-smt2"), List.empty)
-    val results = UclidMain.execute(mainModule.get, config)
+    val results = UclidMain.execute(mainModule.get, instantiateConfig)
     val outputString = UclidMain.stringOutput.toString()
     assert (results.count((e) => e.result.isFalse) == nFail)
 
@@ -319,6 +320,9 @@ class ProcedureVerifSpec extends AnyFlatSpec {
   }
   "test-old-instance-var-2.ucl" should "verify all assertions" in {
     VerifierSpec.expectedFails("./test/test-old-instance-var-2.ucl", 0)
+  }
+  "test-mod-set-analysis-4.ucl" should "verify all assertions" in {
+    VerifierSpec.expectedFails("./test/test-mod-set-analysis-4.ucl", 0, Some(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-4.ucl")))
   }
 }
 class InductionVerifSpec extends AnyFlatSpec {

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -49,7 +49,7 @@ object VerifierSpec {
     UclidMain.enableStringOutput()
     UclidMain.clearStringOutput()
     val config = UclidMain.Config() 
-    val modules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"), true)
+    val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
     val mainModule = UclidMain.instantiate(config, modules, l.Identifier("main"), false)
     assert (mainModule.isDefined)
     // val config = UclidMain.Config("main", List("/usr/bin/z3", "-in", "-smt2"), List.empty)
@@ -525,7 +525,7 @@ object PrintCexSpec {
   def checkPrintCex(filename: String, n : Int) {
     UclidMain.enableStringOutput()
     UclidMain.clearStringOutput()
-    val modules = UclidMain.compile(List(new File(filename)), lang.Identifier("main"), true)
+    val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
     val mainModule = UclidMain.instantiate(UclidMain.Config(), modules, l.Identifier("main"), false)
     assert (mainModule.isDefined)
     val config = UclidMain.Config() 

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -324,6 +324,9 @@ class ProcedureVerifSpec extends AnyFlatSpec {
   "test-mod-set-analysis-4.ucl" should "verify all assertions" in {
     VerifierSpec.expectedFails("./test/test-mod-set-analysis-4.ucl", 0, Some(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-4.ucl")))
   }
+  "test-mod-set-analysis-5.ucl" should "verify all assertions" in {
+    VerifierSpec.expectedFails("./test/test-mod-set-analysis-5.ucl", 0, Some(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-5.ucl")))
+  }
 }
 class InductionVerifSpec extends AnyFlatSpec {
   "test-k-induction-1.ucl" should "verify all assertions." in {

--- a/test/test-mod-set-analysis-0.ucl
+++ b/test/test-mod-set-analysis-0.ucl
@@ -1,0 +1,13 @@
+module main {
+    var x: integer;
+
+    procedure foo() {
+        x = 0;
+    }
+
+    control {
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}

--- a/test/test-mod-set-analysis-1.ucl
+++ b/test/test-mod-set-analysis-1.ucl
@@ -1,0 +1,19 @@
+module main {
+    var x: integer;
+
+    // bar should be infered to modify x
+    procedure bar() {
+       x = 0; 
+    }
+
+    // foo should be infered to modify x
+    procedure foo() {
+        call bar();
+    }
+
+    control {
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}

--- a/test/test-mod-set-analysis-2.ucl
+++ b/test/test-mod-set-analysis-2.ucl
@@ -1,0 +1,21 @@
+module main {
+
+    var x: integer;
+
+    // Should only infer that x is modified
+    procedure foo() {
+        var y: integer;
+        y = 0;
+        x = 0;
+    }
+
+    procedure bar() {
+        call foo();
+    }
+
+    control {
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}

--- a/test/test-mod-set-analysis-2.ucl
+++ b/test/test-mod-set-analysis-2.ucl
@@ -1,6 +1,7 @@
 module main {
 
     var x: integer;
+    var z: integer;
 
     // Should only infer that x is modified
     procedure foo() {
@@ -9,8 +10,16 @@ module main {
         x = 0;
     }
 
+    // Modifies z but not the return value res
+    procedure zap() returns (res: integer) {
+        z = 0;
+        res = z;
+    }
+
     procedure bar() {
+        var tmp: integer;
         call foo();
+        call (tmp) = zap();
     }
 
     control {

--- a/test/test-mod-set-analysis-3.ucl
+++ b/test/test-mod-set-analysis-3.ucl
@@ -1,0 +1,28 @@
+module sub {
+    output x: integer;
+    var z: integer;
+
+    procedure bar() {
+        havoc x;
+        havoc z; 
+    }
+}
+
+module main {
+
+    var x: integer;
+    var y: integer;
+
+    procedure foo() {
+        havoc x;
+        y = x;
+    }
+
+    instance submodule: sub(x: (x));
+
+    control {
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}

--- a/test/test-mod-set-analysis-4.ucl
+++ b/test/test-mod-set-analysis-4.ucl
@@ -1,0 +1,26 @@
+module main {
+
+    var x: integer;
+    var y: integer;
+
+    procedure [noinline] bar()
+        ensures x == old(x) + 1;
+    {
+        x = x + 1;
+    }
+
+    // Check that calling bar does not change y
+    procedure foo()
+        ensures y == old(y);
+        ensures x == old(x) + 1;
+    {
+        call bar();
+    }
+
+    control {
+        v = verify(bar);
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}

--- a/test/test-mod-set-analysis-5.ucl
+++ b/test/test-mod-set-analysis-5.ucl
@@ -1,0 +1,39 @@
+module main {
+
+    var x: integer;
+    var y: integer;
+
+    // Test shadowing local variables
+    procedure [noinline] bar()
+        ensures x == old(x) + 1;
+        modifies x;
+    {
+       var y: integer;
+       {
+         var x: integer;
+         x = 1;
+       }
+       x = x+1; 
+       y = 1; // this is a local var assignment
+       {
+         var x: integer;
+         x = 1;
+       }
+    }
+
+    // Check that calling bar does not change y
+    procedure foo()
+        ensures y == old(y);
+        ensures x == old(x) + 1;
+        modifies x;
+    {
+        call bar();
+    }
+
+    control {
+        v = verify(bar);
+        v = verify(foo);
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
Implemented modifies set analysis passes that can be turned on with the -M option.

The first pass infers the modifies sets for each procedure and stores them in a map from procedure id to sets.

The second pass will combine (1) the original modifies set, (2) the inferred modifies set, and (3) the modifies sets of the callees.

Includes 4 test cases.

NOTE: This does not work with instance procedure calls.

NOTE 2: Passed config into the compile function in UclidMain. As a result, I removed the file argument in the compile function, which changes how all test cases need to be instantiated (you need to specify a Config object instead of a Sequence of File objects). I create a file called Utils.scala in the test directory that contains helper functions for creating these Config files with different options to the solver.  