### PR TITLE
Import module feature

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -190,6 +190,8 @@ object UclidMain {
     passManager.addPass(new ModuleCanonicalizer())
     // introduces LTL operators (which were parsed as function applications)
     passManager.addPass(new LTLOperatorIntroducer())
+    // imports declarations from modules to modules
+    passManager.addPass(new ModuleImportRewriter())
     // imports types into module
     passManager.addPass(new ModuleTypesImportCollector())
     // imports defines

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -195,7 +195,7 @@ object UclidMain {
     passManager.addPass(new ModuleCanonicalizer())
     // introduces LTL operators (which were parsed as function applications)
     passManager.addPass(new LTLOperatorIntroducer())
-    // imports declarations from modules to modules
+    // imports all declarations except init and next declarations into module
     passManager.addPass(new ModuleImportRewriter())
     // imports types into module
     passManager.addPass(new ModuleTypesImportCollector())

--- a/src/main/scala/uclid/lang/ModuleImportRewriter.scala
+++ b/src/main/scala/uclid/lang/ModuleImportRewriter.scala
@@ -60,10 +60,10 @@ class ModuleImportRewriterPass() extends RewritePass {
                   val declsP = mod.decls.filter(decl => !decl.isInstanceOf[InitDecl] && !decl.isInstanceOf[NextDecl])
                   acc ++ declsP
                 }
-                case _ => throw new Utils.RuntimeError("%s is not a module type. Failed to import into %s.".format(moduleToImportId, module.id))
+                case _ => throw new Utils.ParserError("%s is not a module type. Failed to import into %s".format(moduleToImportId, module.id), Some(modImportDecl.pos), modImportDecl.filename)
               }
             }
-            case None => throw new Utils.RuntimeError("Module %s not found. Failed to import into %s.".format(moduleToImportId, module.id))
+            case None => throw new Utils.ParserError("Module %s not found. Failed to import into %s".format(moduleToImportId, module.id), Some(modImportDecl.pos), modImportDecl.filename)
           }
         }
       )

--- a/src/main/scala/uclid/lang/ModuleImportRewriter.scala
+++ b/src/main/scala/uclid/lang/ModuleImportRewriter.scala
@@ -32,7 +32,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Kevin Cheang
- * Rewrite import moduleId; declarations. This copies all declarations from the module named moduleId to the declaring module.
+ * Rewrite import moduleId; declarations. This copies all declarations from the module named moduleId to the declaring module
+ * with the exception of init and next block declarations.
  *
  */
 
@@ -46,7 +47,7 @@ class ModuleImportRewriterPass() extends RewritePass {
     // remove the import module declarations
     val declsP = module.decls.filter(decl => !decl.isInstanceOf[ModuleImportDecl])
 
-    // add all imported modules
+    // add all declarations from imported modules (except init and next block declarations)
     val declsPP = module
       .moduleImportDecls
       .foldLeft(declsP)(

--- a/src/main/scala/uclid/lang/ModuleImportRewriter.scala
+++ b/src/main/scala/uclid/lang/ModuleImportRewriter.scala
@@ -1,0 +1,76 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2017.
+ * Sanjit A. Seshia, Rohit Sinha and Pramod Subramanyan.
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Kevin Cheang
+ * Rewrite import moduleId; declarations. This copies all declarations from the module named moduleId to the declaring module.
+ *
+ */
+
+package uclid
+package lang
+
+/** Rewrites the module's import declarations
+  */
+class ModuleImportRewriterPass() extends RewritePass {
+  override def rewriteModule(module : Module, ctx : Scope) : Option[Module] = {
+    // remove the import module declarations
+    val declsP = module.decls.filter(decl => !decl.isInstanceOf[ModuleImportDecl])
+
+    // add all imported modules
+    val declsPP = module
+      .moduleImportDecls
+      .foldLeft(declsP)(
+        (acc, modImportDecl) => {
+          val moduleToImportId = modImportDecl.modId
+          ctx.get(moduleToImportId) match {
+            case Some(namedExpr) => {
+              namedExpr match {
+                case Scope.ModuleDefinition(mod) => {
+                  // remove the init and next declarations
+                  val declsP = mod.decls.filter(decl => !decl.isInstanceOf[InitDecl] && !decl.isInstanceOf[NextDecl])
+                  acc ++ declsP
+                }
+                case _ => throw new Utils.RuntimeError("%s is not a module type. Failed to import into %s.".format(moduleToImportId, module.id))
+              }
+            }
+            case None => throw new Utils.RuntimeError("Module %s not found. Failed to import into %s.".format(moduleToImportId, module.id))
+          }
+        }
+      )
+
+    val moduleP = Module(module.id, declsPP, module.cmds, module.notes)
+    Some(moduleP)
+  }
+}
+
+class ModuleImportRewriter() extends ASTRewriter("ModuleImportRewriter", new ModuleImportRewriterPass())

--- a/src/main/scala/uclid/lang/Scope.scala
+++ b/src/main/scala/uclid/lang/Scope.scala
@@ -272,7 +272,8 @@ case class Scope (
         //case ModuleFunctionsImportDecl(id) => Scope.addToMap(mapAcc, Scope.FunctionsImport(id))
         case ModuleConstantsImportDecl(_) => mapAcc
         case ModuleFunctionsImportDecl(_) => mapAcc
-        case ModuleTypesImportDecl(_) | 
+        case ModuleImportDecl(_) |
+             ModuleTypesImportDecl(_) | 
              ModuleDefinesImportDecl(_) | 
              InitDecl(_) | NextDecl(_)  => mapAcc
       }
@@ -306,7 +307,7 @@ case class Scope (
         case SharedVarsDecl(_, typ) => Scope.addTypeToMap(mapAcc, typ, Some(m))
         case ConstantLitDecl(_, lit) => Scope.addTypeToMap(mapAcc, lit.typeOf, Some(m))
         case ConstantsDecl(_, typ) => Scope.addTypeToMap(mapAcc, typ, Some(m))
-        case ModuleTypesImportDecl(_) | ModuleConstantsImportDecl(_) |
+        case ModuleImportDecl(_) | ModuleTypesImportDecl(_) | ModuleConstantsImportDecl(_) |
              ModuleFunctionsImportDecl(_) | ModuleDefinesImportDecl(_) |
              InstanceDecl(_, _, _, _, _) | SpecDecl(_, _, _) | 
              AxiomDecl(_, _, _) | InitDecl(_) | NextDecl(_) => mapAcc

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1188,6 +1188,10 @@ case class TypeDecl(id: Identifier, typ: Type) extends Decl {
   override def toString = "type " + id + " = " + typ + "; // " + position.toString
   override def declNames = List(id)
 }
+case class ModuleImportDecl(modId: Identifier) extends Decl {
+  override def toString = "import %s;".format(modId.toString())
+  override def declNames = List.empty
+}
 case class ModuleTypesImportDecl(id : Identifier) extends Decl {
   override def toString = "type * = %s.*; // %s".format(id.toString(), position.toString())
   override def declNames = List.empty
@@ -1475,6 +1479,10 @@ case class Module(id: Identifier, decls: List[Decl], cmds : List[GenericProofCom
   lazy val constants : List[(Identifier, Type)] =
     constantDecls.flatMap(cnst => cnst.ids.map(id => (id, cnst.typ)))
   
+  // module imports.
+  lazy val moduleImportDecls : List[ModuleImportDecl] = decls.collect { case decl : ModuleImportDecl => decl }
+  
+  // module function imports.
   lazy val funcImportDecls : List[ModuleFunctionsImportDecl] = decls.collect {
   case imp : ModuleFunctionsImportDecl => imp }
   

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -149,6 +149,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwRange = "range"
     lazy val KwWhile = "while"
     lazy val KwInstance = "instance"
+    lazy val KwImport = "import"
     lazy val KwType = "type"
     lazy val KwInput = "input"
     lazy val KwOutput = "output"
@@ -190,7 +191,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       OpBiImpl, OpImpl, OpLT, OpGT, OpLE, OpGE, OpULT, OpUGT, OpULE, OpUGE, OpEQ, OpNE,
       OpBvAnd, OpBvOr, OpBvXor, OpBvUrem, OpBvSrem, OpBvNot, OpConcat, OpNot, OpMinus, OpPrime,
       "false", "true", "bv", KwProcedure, KwBoolean, KwInteger, KwReturns,
-      KwAssume, KwAssert, KwSharedVar, KwVar, KwHavoc, KwCall,
+      KwAssume, KwAssert, KwSharedVar, KwVar, KwHavoc, KwCall, KwImport,
       KwIf, KwThen, KwElse, KwCase, KwEsac, KwFor, KwIn, KwRange, KwWhile,
       KwInstance, KwInput, KwOutput, KwConst, KwModule, KwType, KwEnum,
       KwRecord, KwSkip, KwDefine, KwFunction, KwControl, KwInit,
@@ -583,6 +584,10 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       KwType ~> Id <~ ";" ^^ { case id => lang.TypeDecl(id, lang.UninterpretedType(id)) }
     }
 
+    lazy val ModuleImportDecl : PackratParser[lang.ModuleImportDecl] = positioned {
+      KwImport ~> Id <~ ";" ^^ { case id => lang.ModuleImportDecl(id) }
+    }
+
     lazy val ModuleTypesImportDecl : PackratParser[lang.ModuleTypesImportDecl] = positioned {
       KwType ~ "*" ~ "=" ~> Id <~ "." ~ "*" ~ ";" ^^ { case id => lang.ModuleTypesImportDecl(id) }
     }
@@ -766,7 +771,8 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
                   SynthFuncDecl | DefineDecl | ModuleDefsImportDecl | GrammarDecl |
                   VarsDecl | InputsDecl | OutputsDecl | SharedVarsDecl |
                   ConstLitDecl | ConstDecl | ProcedureDecl |
-                  InitDecl | NextDecl | SpecDecl | AxiomDecl)
+                  InitDecl | NextDecl | SpecDecl | AxiomDecl |
+                  ModuleImportDecl)
 
     // control commands.
     lazy val CmdParam : PackratParser[lang.CommandParams] = 

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -282,6 +282,30 @@ class ParserSpec extends AnyFlatSpec {
         assert (p.errors.exists(p => p._1.contains("Return type and expression type do not match")))
     }
   }
+  "test-module-import-1.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(List(new File("test/test-module-import-1.ucl")), lang.Identifier("main"))
+      // should never get here.
+      // assert (false);
+    }
+    catch {
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size == 1)
+        assert (p.errors(0)._1.contains("Redeclaration of identifier 'bar'."))
+    }
+  }
+  "test-module-import-2.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(List(new File("test/test-module-import-2.ucl")), lang.Identifier("main"))
+      // should never get here.
+      assert (false);
+    }
+    catch {
+      // this list has all the errors from parsing
+      case p : Utils.ParserError =>
+        assert (p.getMessage().contains("Module module1 not found. Failed to import into main"))
+    }
+  }
   "test-types-import-redecl.ucl" should "not parse successfully." in {
     try {
       val fileModules = UclidMain.compile(List(new File("test/test-types-import-redecl.ucl")), lang.Identifier("main"))

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -304,7 +304,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-module-import-1.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-module-import-1.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-module-import-1.ucl"), lang.Identifier("main"))
       // should never get here.
       // assert (false);
     }
@@ -316,7 +316,7 @@ class ParserSpec extends AnyFlatSpec {
   }
   "test-module-import-2.ucl" should "not parse successfully." in {
     try {
-      val fileModules = UclidMain.compile(List(new File("test/test-module-import-2.ucl")), lang.Identifier("main"))
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-module-import-2.ucl"), lang.Identifier("main"))
       // should never get here.
       assert (false);
     }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -374,6 +374,9 @@ class ModuleVerifSpec extends AnyFlatSpec {
   "test-modules-6.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-modules-6.ucl", 0)
   }
+  "test-module-import-0.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-module-import-0.ucl", 0)
+  }
   "test-type-import.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-type-import.ucl", 0)
   }

--- a/test/test-module-import-0.ucl
+++ b/test/test-module-import-0.ucl
@@ -1,0 +1,49 @@
+module common {
+    type T = integer;
+}
+
+module module1 {
+    type * = common.*;
+
+    var x: integer;
+
+    define bar(x: T): T = x;
+
+    function gar(x: T): T;
+
+    procedure zar(x: T) returns (res: T) {
+        res = x + 1;
+    }
+}
+
+// Import all of module1
+module main {
+    import module1;
+
+    procedure foo()
+        modifies x;
+        ensures x == old(x) + 1;
+    {
+        var z: T;
+        z = gar(x);
+        call (x) = zar(bar(x));
+    }
+
+    invariant x_always_positive: x > 0;
+
+    init {
+        x = 1;
+    }
+
+    next {
+        x' = x + 1;
+    }
+
+    control {
+        v = verify(foo);
+        u = unroll(5);
+        check;
+        print_results;
+        u.print_cex();
+    }
+}

--- a/test/test-module-import-0.ucl
+++ b/test/test-module-import-0.ucl
@@ -3,7 +3,7 @@ module common {
 }
 
 module module1 {
-    type * = common.*;
+    import common;
 
     var x: integer;
 

--- a/test/test-module-import-1.ucl
+++ b/test/test-module-import-1.ucl
@@ -1,0 +1,13 @@
+module module1 {
+    define bar(x: integer): integer = x;
+}
+
+module module2 {
+    import module1;
+}
+
+// Conflicting bar definitions
+module main {
+    import module1;
+    import module2;
+}

--- a/test/test-module-import-2.ucl
+++ b/test/test-module-import-2.ucl
@@ -1,0 +1,4 @@
+// Non-existant module1
+module main {
+    import module1;
+}


### PR DESCRIPTION
Feature implementation for module import.

`import module_name;` imports all declarations (**except for the init and next blocks**) from the module named `module_name` into the declaring module.

This happens at the beginning of the UCLID5 compiler pass.

NOTE: I didn't import the init and next blocks partly because this would have to happen in a separate preprocessing step before the compiler pass (which applies all of the passes on a module before the parent module). Otherwise, placing the pass in the compiler pass will result in unprimed variables of a next block (after a full compiler pass) to be imported into the parent module which has not gone through the compilation pass and thus requires all LHS in the next block to be primed variables during the compile pass. It seems like we should introduce a preprocessing pass at some point to have more separation between the passes.