### PR TITLE
Introduce oracle functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,15 +52,15 @@ jobs:
     - name: Print CVC4 Version
       run: cvc4 --version
 
-    - name: Cache Delphi
-      id: cache-delphi
-      uses: actions/cache@v1
-      with:
-        path: delphi/
-        key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-linux.sh') }}-1
+    # - name: Cache Delphi
+    #   id: cache-delphi
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: delphi/
+    #     key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-linux.sh') }}-1
 
     - name: Download delphi
-      if: steps.cache-delphi.outputs.cache-hit != 'true'
+      # if: steps.cache-delphi.outputs.cache-hit != 'true'
       run: ./get-delphi-linux.sh
 
     - name: Add delphi to Path
@@ -148,15 +148,15 @@ jobs:
     - name: Print CVC4 Version
       run: cvc4 --version
 
-    - name: Cache delphi
-      id: cache-delphi
-      uses: actions/cache@v1
-      with:
-        path: delphi/
-        key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-macos.sh') }}-1
+    # - name: Cache delphi
+    #   id: cache-delphi
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: delphi/
+    #     key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-macos.sh') }}-1
 
     - name: Download delphi
-      if: steps.cache-delphi.outputs.cache-hit != 'true'
+      # if: steps.cache-delphi.outputs.cache-hit != 'true'
       run: ./get-delphi-macos.sh
 
     - name: Add delphi to Path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,27 @@ jobs:
     - name: Print CVC4 Version
       run: cvc4 --version
 
+    - name: Cache Delphi
+      id: cache-delphi
+      uses: actions/cache@v1
+      with:
+        path: delphi/
+        key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-linux.sh') }}-1
+
+    - name: Download delphi
+      if: steps.cache-delphi.outputs.cache-hit != 'true'
+      run: ./get-delphi-linux.sh
+
+    - name: Add delphi to Path
+      run: |
+       ls $GITHUB_WORKSPACE/delphi/bin/
+       echo "$GITHUB_WORKSPACE/delphi/bin/" >> $GITHUB_PATH
+    
+    - name: Add oracles to Path
+      run: |
+       ls $GITHUB_WORKSPACE/oracles/
+       echo "$GITHUB_WORKSPACE/oracles/" >> $GITHUB_PATH
+    
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -126,6 +147,26 @@ jobs:
 
     - name: Print CVC4 Version
       run: cvc4 --version
+
+    - name: Cache delphi
+      id: cache-delphi
+      uses: actions/cache@v1
+      with:
+        path: delphi/
+        key: ${{ runner.os }}-delphi-${{ hashFiles('get-delphi-macos.sh') }}-1
+
+    - name: Download delphi
+      if: steps.cache-delphi.outputs.cache-hit != 'true'
+      run: ./get-delphi-macos.sh
+
+    - name: Add delphi to Path
+      run: |
+       ls $GITHUB_WORKSPACE/delphi/bin/
+       echo "$GITHUB_WORKSPACE/delphi/bin/" >> $GITHUB_PATH
+    - name: Add oracles to Path
+      run: |
+       ls $GITHUB_WORKSPACE/oracles/
+       echo "$GITHUB_WORKSPACE/oracles/" >> $GITHUB_PATH
 
     - name: Compile
       run: sbt compile

--- a/get-delphi-linux.sh
+++ b/get-delphi-linux.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+wget https://github.com/polgreen/delphi/releases/download/0.1/delphi_linux
+
+mkdir -p delphi/bin/
+mv delphi_linux delphi/bin/delphi
+
+chmod 755 delphi/bin/delphi
+export PATH=$PATH:$PWD/delphi/bin
+

--- a/get-delphi-macos.sh
+++ b/get-delphi-macos.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+wget https://github.com/polgreen/delphi/releases/download/0.1/delphi_mac
+
+mkdir -p delphi/bin/
+mv delphi_mac delphi/bin/delphi
+
+chmod 755 delphi/bin/delphi
+export PATH=$PATH:$PWD/delphi/bin
+

--- a/oracles/isprime
+++ b/oracles/isprime
@@ -1,0 +1,8 @@
+#!/bin/bash  
+if [[ "$1" == "2" ]] ; then
+	echo "true"
+elif [[ "$1" == "19" ]] ; then
+	echo "true"
+else
+	echo "false"
+fi

--- a/oracles/issquare
+++ b/oracles/issquare
@@ -1,0 +1,12 @@
+#!/bin/bash  
+if [[ "$1" == "2" ]] ; then
+	echo "true"
+elif [[ "$1" == "4" ]] ; then
+	echo "true"
+elif [[ "$1" == "9" ]] ; then
+	echo "true"
+elif [[ "$1" == "16" ]] ; then
+	echo "true"	
+else
+	echo "false"
+fi

--- a/src/main/scala/uclid/AssertionTree.scala
+++ b/src/main/scala/uclid/AssertionTree.scala
@@ -148,7 +148,7 @@ class AssertionTree {
     override val isAssert = false
   }
 
-  def _verify(node : TreeNode, solver : smt.Context, mode : VerifyMode, getModel : Boolean = true) : List[CheckResult] = {
+  def _verify(node : TreeNode, solver : smt.Context, mode : VerifyMode, getModel : Boolean) : List[CheckResult] = {
     if (mode.isAssert) {
       solver.push()
       node.assumptions.foreach(a => solver.assert(a))
@@ -193,15 +193,15 @@ class AssertionTree {
     }
     // now recurse into children
     if (mode.isAssert) {
-        val childResults = node.children.flatMap(c => _verify(c, solver, mode))
+        val childResults = node.children.flatMap(c => _verify(c, solver, mode, getModel))
         solver.pop()
         node.results ++ childResults
     } else {
-        node.children.foreach(c => _verify(c, solver, mode))
+        node.children.foreach(c => _verify(c, solver, mode, getModel))
         List.empty
     }
   }
-  def verify(solver : smt.Context, getModel: Boolean=true) : List[CheckResult] = {
+  def verify(solver : smt.Context, getModel: Boolean) : List[CheckResult] = {
     _verify(root, solver, VerifyModePreprocess, getModel)
     _verify(root, solver, VerifyModeAssert, getModel)
   }

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -288,10 +288,10 @@ class SymbolicSimulator (module : Module) {
             }
             verifyProcedure(proc, label)
           case "check" => {
-            val getModel = module.cmds.contains("print_cex")
+            val needModel = module.cmds.filter(p => p.isPrintCEX).size > 0
             lazySC match {
-              case None => proofResults = assertionTree.verify(solver, getModel)
-              case Some(lz) => proofResults = lz.assertionTree.verify(solver, getModel)
+              case None => proofResults = assertionTree.verify(solver, needModel)
+              case Some(lz) => proofResults = lz.assertionTree.verify(solver, needModel)
             }
             if (solver.filePrefix != "") {
               val smtOutput = solver.toString()
@@ -724,7 +724,8 @@ class SymbolicSimulator (module : Module) {
       }
     }
     symbolTable = symTabStep
-    val results = assertionTree.verify(solver)
+    val needModel = module.cmds.filter(p => p.isPrintCEX).size > 0
+    val results = assertionTree.verify(solver, needModel)
     UclidMain.println("The results are: " + results)
   }
 

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -73,9 +73,10 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
                Scope.FunctionArg(_, _)    | Scope.Define(_, _, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
+               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.OracleFunction(_, _, _) =>
              true
-          case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)             |
+          case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)          |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |

--- a/src/main/scala/uclid/lang/Scope.scala
+++ b/src/main/scala/uclid/lang/Scope.scala
@@ -59,6 +59,7 @@ object Scope {
   case class Function(fId : Identifier, fTyp: Type) extends ReadOnlyNamedExpression(fId, fTyp)
   case class Grammar(gId : Identifier, gTyp : Type, nts : List[NonTerminal]) extends ReadOnlyNamedExpression(gId, gTyp)
   case class SynthesisFunction(fId : Identifier, fTyp: FunctionSig, gId: Option[Identifier], gargs: List[Identifier], conds : List[Expr]) extends ReadOnlyNamedExpression(fId, fTyp.typ)
+  case class OracleFunction(oId : Identifier, oTyp: FunctionSig, binary: String) extends ReadOnlyNamedExpression(oId, oTyp.typ)
   case class Define(dId : Identifier, dTyp : Type, defDecl: DefineDecl) extends ReadOnlyNamedExpression(dId, dTyp)
   case class Procedure(pId : Identifier, pTyp: Type) extends ReadOnlyNamedExpression(pId, pTyp)
   case class ProcedureInputArg(argId : Identifier, argTyp: Type) extends ReadOnlyNamedExpression(argId, argTyp)
@@ -262,6 +263,7 @@ case class Scope (
         case GrammarDecl(id, sig, nts) => Scope.addToMap(mapAcc, Scope.Grammar(id, sig.typ, nts))
         case FunctionDecl(id, sig) => Scope.addToMap(mapAcc, Scope.Function(id, sig.typ))
         case SynthesisFunctionDecl(id, sig, gid, gargs, conds) => Scope.addToMap(mapAcc, Scope.SynthesisFunction(id, sig, gid, gargs, conds))
+        case OracleFunctionDecl(id, sig, binary) => Scope.addToMap(mapAcc, Scope.OracleFunction(id, sig, binary))
         case DefineDecl(id, sig, expr) => Scope.addToMap(mapAcc, Scope.Define(id, sig.typ, DefineDecl(id, sig, expr)))
         case SpecDecl(id, expr, params) => Scope.addToMap(mapAcc, Scope.SpecVar(id, expr, params))
         case AxiomDecl(sId, expr, params) => sId match {
@@ -293,6 +295,10 @@ case class Scope (
           val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
           m2
         case SynthesisFunctionDecl(_, sig, _, _, _) =>
+          val m1 = sig.args.foldLeft(mapAcc)((mapAcc2, operand) => Scope.addTypeToMap(mapAcc2, operand._2, Some(m)))
+          val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
+          m2
+        case OracleFunctionDecl(_, sig, _) =>
           val m1 = sig.args.foldLeft(mapAcc)((mapAcc2, operand) => Scope.addTypeToMap(mapAcc2, operand._2, Some(m)))
           val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
           m2

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -72,6 +72,7 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
+               Scope.OracleFunction(_,_,_) |
                Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)          |
@@ -130,7 +131,7 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.ConstantLit(_, _)        | Scope.BlockVar(_, _)            |
                Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          =>
               id
-          case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.SynthesisFunction(_, _, _, _, _) =>
+          case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.OracleFunction(_,_,_) | Scope.SynthesisFunction(_, _, _, _, _) =>
              ExternalIdentifier(moduleName, id)
         }
       case None =>

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1411,6 +1411,7 @@ case class GenericProofCommand(
     val objStr = argObj match { case Some(id) => id.toString + "->"; case None => "" }
     resultStr + objStr + nameStr + paramStr + argStr + ";" + " // " + position.toString
   }
+  def isPrintCEX : Boolean = { name == Identifier("print_cex") }
 }
 
 sealed abstract class Annotation extends ASTNode

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1319,6 +1319,11 @@ case class SynthesisFunctionDecl(id: Identifier, sig: FunctionSig, grammarId : O
   override def declNames = List(id)
 }
 
+case class OracleFunctionDecl(id: Identifier, sig: FunctionSig, binary: String) extends Decl {
+  override def toString = "oracle function [" + binary + "]" + id + sig + "; //" + position.toString()
+  override def declNames = List(id)
+}
+
 case class InitDecl(body: Statement) extends Decl {
   override def toString =
     "init // " + position.toString + "\n" +

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -158,6 +158,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwModule = "module"
     lazy val KwLambda = "lambda"
     lazy val KwFunction = "function"
+    lazy val KwOracle = "oracle"
     lazy val KwControl = "control"
     lazy val KwForall = "forall"
     lazy val KwExists = "exists"
@@ -194,7 +195,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       KwAssume, KwAssert, KwSharedVar, KwVar, KwHavoc, KwCall, KwImport,
       KwIf, KwThen, KwElse, KwCase, KwEsac, KwFor, KwIn, KwRange, KwWhile,
       KwInstance, KwInput, KwOutput, KwConst, KwModule, KwType, KwEnum,
-      KwRecord, KwSkip, KwDefine, KwFunction, KwControl, KwInit,
+      KwRecord, KwSkip, KwDefine, KwFunction, KwOracle, KwControl, KwInit,
       KwNext, KwLambda, KwModifies, KwProperty, KwDefineAxiom,
       KwForall, KwExists, KwDefault, KwSynthesis, KwGrammar, KwRequires,
       KwEnsures, KwInvariant, KwParameter, 
@@ -539,6 +540,9 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val ProcedureAnnotationList : PackratParser[List[Identifier]] = {
       "[" ~> IdList <~ "]"
     }
+    lazy val SingleAnnotation: PackratParser[Identifier] = {
+      "[" ~> Id <~ "]"
+    }
     lazy val ProcedureVerifExpr = RequiresExprs | EnsuresExprs | ModifiesExprs
 
     def collectRequires(vs : List[lang.ProcedureVerificationExpr]) : List[Expr] = {
@@ -617,6 +621,10 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val FuncDecl : PackratParser[lang.FunctionDecl] = positioned {
       KwFunction ~> Id ~ IdTypeList ~ (":" ~> Type) <~ ";" ^^
       { case id ~ idtyps ~ rt => lang.FunctionDecl(id, lang.FunctionSig(idtyps, rt)) }
+    }
+    lazy val OracleFuncDecl : PackratParser[lang.OracleFunctionDecl] = positioned {
+      KwOracle ~ KwFunction ~> SingleAnnotation ~ Id ~ IdTypeList ~ (":" ~> Type) <~ ";" ^^
+      { case annotation ~ id ~ idtyps ~ rt => lang.OracleFunctionDecl(id, lang.FunctionSig(idtyps, rt), annotation.toString) }
     }
     lazy val ModuleFuncsImportDecl : PackratParser[lang.ModuleFunctionsImportDecl] = positioned {
       KwFunction ~ "*" ~ "=" ~> Id <~ "." ~ "*" ~ ";" ^^ { case id => lang.ModuleFunctionsImportDecl(id) }
@@ -766,7 +774,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     }
 
     lazy val Decl: PackratParser[Decl] =
-      positioned (InstanceDecl | TypeDecl | ConstDecl | FuncDecl |
+      positioned (InstanceDecl | TypeDecl | ConstDecl | FuncDecl | OracleFuncDecl |
                   ModuleTypesImportDecl | ModuleFuncsImportDecl | ModuleConstsImportDecl |
                   SynthFuncDecl | DefineDecl | ModuleDefsImportDecl | GrammarDecl |
                   VarsDecl | InputsDecl | OutputsDecl | SharedVarsDecl |

--- a/src/main/scala/uclid/smt/Context.scala
+++ b/src/main/scala/uclid/smt/Context.scala
@@ -262,7 +262,8 @@ object Context
       case Some(eP) => eP
       case None =>
         val eP = e match {
-          case Symbol(_, _) | IntLit(_) | BitVectorLit(_, _) | BooleanLit(_) | BooleanLit(_) | EnumLit(_, _) | ConstArray(_, _) | SynthSymbol (_, _, _, _, _) =>
+          case Symbol(_, _) | IntLit(_) | BitVectorLit(_, _) | BooleanLit(_) | BooleanLit(_) | EnumLit(_, _) | 
+            ConstArray(_, _) | SynthSymbol (_, _, _, _, _) | OracleSymbol(_, _, _) =>
             rewrite(e)
           case OperatorApplication(op, operands) =>
             val operandsP = operands.map(arg => rewriteExpr(arg, rewrite, memo))
@@ -324,7 +325,7 @@ object Context
       case None =>
         val eResult = apply(e)
         val results = e match {
-          case Symbol(_, _) | IntLit(_) | BitVectorLit(_,_) | BooleanLit(_) | EnumLit(_, _) | SynthSymbol(_, _, _, _, _) =>
+          case Symbol(_, _) | IntLit(_) | BitVectorLit(_,_) | BooleanLit(_) | EnumLit(_, _) | SynthSymbol(_, _, _, _, _) | OracleSymbol(_, _, _) =>
             eResult
           case ConstArray(expr, _) =>
             eResult ++ accumulateOverExpr(expr, apply, memo)
@@ -390,7 +391,7 @@ object Context
 
   def foldOverExpr[T](init : T, f : ((T, Expr) => T), e : Expr) : T = {
     val subResult = e match {
-      case Symbol(_, _) | IntLit(_) | BitVectorLit(_, _) | BooleanLit(_) | EnumLit(_, _) | SynthSymbol(_, _, _, _, _) =>
+      case Symbol(_, _) | IntLit(_) | BitVectorLit(_, _) | BooleanLit(_) | EnumLit(_, _) | SynthSymbol(_, _, _, _, _) | OracleSymbol(_, _, _) =>
         init
       case OperatorApplication(_, operands) =>
         foldOverExprs(init, f, operands)

--- a/src/main/scala/uclid/smt/SExprParser.scala
+++ b/src/main/scala/uclid/smt/SExprParser.scala
@@ -252,6 +252,7 @@ object SExprParser extends SExprTokenParsers with PackratParsers {
 
   // Need to add to deal with Z3 output
   lazy val KwDecFun = "declare-fun"
+  
 
 
   lexical.delimiters += ("(", ")")

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -854,6 +854,12 @@ case class GrammarSymbol(id: String, symbolTyp: Type, nts : List[NonTerminal]) e
   override val md5hashCode = computeMD5Hash(id, symbolTyp)
   override def toString = id.toString
 }
+case class OracleSymbol(id: String, symbolTyp: lang.FunctionSig, binary : String) extends Expr (smt.Converter.typeToSMT(symbolTyp.typ)) {
+  override val hashId = mix(id.hashCode(), mix(symbolTyp.typ.hashCode(), 317))
+  override val hashCode = computeHash
+  override val md5hashCode = computeMD5Hash(id)
+  override def toString = id.toString
+}
 
 class Bindings(val freeVars : List[Symbol], val letVars : List[Symbol], val lambdaVars : List[Symbol], val quantifierVars: List[Symbol]) {
   def addFreeVar(v : Symbol) = {

--- a/src/test/scala/OracleSpec.scala
+++ b/src/test/scala/OracleSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2017.
+ * Sanjit A. Seshia, Rohit Sinha and Pramod Subramanyan.
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Elizabeth Polgreen
+ *
+ * UCLID oracle tests
+ *
+ */
+
+package uclid
+package test
+
+import org.scalatest.flatspec.AnyFlatSpec
+import java.io.File
+import uclid.{lang => l}
+
+object OracleSpec {
+  def expectedFails(filename: String, nFail : Int) : String = {
+    UclidMain.enableStringOutput()
+    UclidMain.clearStringOutput()
+    val config = UclidMain.Config().copy(smtSolver=List("delphi", "--smto"))
+    val modules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"), true)
+    val mainModule = UclidMain.instantiate(config, modules, l.Identifier("main"), false)
+    assert (mainModule.isDefined)
+    val results = UclidMain.execute(mainModule.get, config)
+    val outputString = UclidMain.stringOutput.toString()
+    assert (results.count((e) => e.result.isFalse) == nFail)
+
+    assert (results.count((e) => e.result.isUndefined) == 0)
+    outputString
+  }
+}
+class OracleSpec extends AnyFlatSpec {
+  
+  "test-oracle-function-1.ucl" should "fail one assertion." in {
+    OracleSpec.expectedFails("./test/test-oracle-function-1.ucl", 1)
+  }
+}

--- a/src/test/scala/OracleSpec.scala
+++ b/src/test/scala/OracleSpec.scala
@@ -65,4 +65,7 @@ class OracleSpec extends AnyFlatSpec {
   "test-oracle-function-1.ucl" should "fail one assertion." in {
     OracleSpec.expectedFails("./test/test-oracle-function-1.ucl", 1)
   }
+  "test-oracle-function-5.ucl" should "fail one assertion." in {
+    OracleSpec.expectedFails("./test/test-oracle-function-5.ucl", 1)
+  }
 }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -774,5 +774,37 @@ class ParserSpec extends AnyFlatSpec {
       case _: Throwable => assert (false)
     }
   }
+  "test-oracle-function-1.ucl" should "parse successfully" in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-1.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-oracle-function-2.ucl" should "not parse successfully" in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-2.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.ParserError => assert (true)
+      case _: Throwable => assert (false)
+    }
+  }
+  "test-oracle-function-3.ucl" should "not parse successfully" in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-3.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.ParserError => assert (true)
+      case _: Throwable => assert (false)
+    }
+  }
+  "test-oracle-function-4.ucl" should "not parse successfully" in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-4.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.ParserError => assert (true)
+      case _: Throwable => assert (false)
+    }
+  }
 
 }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -774,11 +774,6 @@ class ParserSpec extends AnyFlatSpec {
       case _: Throwable => assert (false)
     }
   }
-  "test-oracle-function-1.ucl" should "parse successfully" in {
-    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-1.ucl"), lang.Identifier("main"))
-    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
-    assert (instantiatedModules.size == 1)
-  }
   "test-oracle-function-2.ucl" should "not parse successfully" in {
     try {
       val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-oracle-function-2.ucl"), lang.Identifier("main"))

--- a/test/test-oracle-function-1.ucl
+++ b/test/test-oracle-function-1.ucl
@@ -11,7 +11,7 @@ module main {
   next{}
 
   
-// this finds prime factors of 76
+// this finds prime factors of 76 (invariant fails if prime factors are found)
   invariant find_factors : (factor1*factor3)*factor2!=76;
 
   control {

--- a/test/test-oracle-function-1.ucl
+++ b/test/test-oracle-function-1.ucl
@@ -1,0 +1,22 @@
+module main {
+  var factor1: integer;
+  var factor2: integer;
+  var factor3: integer;
+
+// should parse
+  oracle function [isprime] isPrime(x: integer) : boolean;
+
+  axiom isPrime(factor1) && isPrime(factor2) && isPrime(factor3);
+  init{}
+  next{}
+
+  
+// this finds prime factors of 76
+  invariant find_factors : (factor1*factor3)*factor2!=76;
+
+  control {
+    v = unroll(0);
+    check;
+    print_results;
+  }
+}

--- a/test/test-oracle-function-2.ucl
+++ b/test/test-oracle-function-2.ucl
@@ -1,0 +1,9 @@
+module main {
+  var factor1: integer;
+  var factor2: integer;
+  var factor3: integer;
+
+// should not parse
+  oracle function [isprime, anotherannotation] isPrime(x: integer): boolean;
+  
+}

--- a/test/test-oracle-function-3.ucl
+++ b/test/test-oracle-function-3.ucl
@@ -8,7 +8,5 @@ module main {
 
   axiom isPrime(factor1) && isPrime(factor2) && isPrime(factor3);
   
-// this finds prime factors of 76
-
 
 }

--- a/test/test-oracle-function-3.ucl
+++ b/test/test-oracle-function-3.ucl
@@ -1,0 +1,14 @@
+module main {
+  var factor1: integer;
+  var factor2: integer;
+  var factor3: integer;
+
+// should not parse
+  oracle function isPrime(x: integer): boolean;
+
+  axiom isPrime(factor1) && isPrime(factor2) && isPrime(factor3);
+  
+// this finds prime factors of 76
+
+
+}

--- a/test/test-oracle-function-4.ucl
+++ b/test/test-oracle-function-4.ucl
@@ -6,6 +6,4 @@ module main {
 // should not parse
   oracle function [isprime] isPrime(x: integer);
 
-  // this finds prime factors of 76
-
 }

--- a/test/test-oracle-function-4.ucl
+++ b/test/test-oracle-function-4.ucl
@@ -1,0 +1,11 @@
+module main {
+  var factor1: integer;
+  var factor2: integer;
+  var factor3: integer;
+
+// should not parse
+  oracle function [isprime] isPrime(x: integer);
+
+  // this finds prime factors of 76
+
+}

--- a/test/test-oracle-function-5.ucl
+++ b/test/test-oracle-function-5.ucl
@@ -1,0 +1,23 @@
+// https://connect.collins.co.uk/repo1/Content/Live/JI/Leckie/GCSE-Maths-Student-Book-Edexcel-Final-03-MarSAMPLEBOOK/wrapper/index.html?r=t#23
+
+module main {
+  var n: integer;
+
+
+// should parse
+  oracle function [issquare] isSquare(x: integer) : boolean;
+
+  axiom  n==12 || n==8 || n==13 || n==17 || n==25 || n==9 || n==10 || n==18 || n==16 || n==6;
+
+  init{}
+  next{}
+
+// invariant fails if there is an n that is square
+  invariant find_factors : !isSquare(n);
+
+  control {
+    v = unroll(0);
+    check;
+    print_results;
+  }
+}


### PR DESCRIPTION
This introduces oracle functions, which are functions whose interpretation is associated to an external binary:

Example of the syntax fo a function with an external implementation binary "isprime":
~~~
oracle function [isprime] isPrime(x: integer) : boolean;
~~~

They can then be used like a normal function in all ways, except they can't be imported (this is similar to synthesis functions)

See test/test-oracle-function-1.ucl

To make the CI work, this downloads https://github.com/polgreen/delphi, and implements a couple of dumb oracles as bash scripts e.g., https://github.com/uclid-org/uclid/pull/94/files#diff-77f7f528d55451246db1c9a122f0cae404d1cd4c329d4b6e8469092df1d4a3df

