### PR TITLE
Mod set analysis fix

### DIFF
--- a/test/test-mod-set-analysis-3.ucl
+++ b/test/test-mod-set-analysis-3.ucl
@@ -15,7 +15,11 @@ module main {
 
     procedure foo() {
         havoc x;
-        y = x;
+        if (true) {
+          {
+            y = x;
+          }
+        }
     }
 
     instance submodule: sub(x: (x));


### PR DESCRIPTION
The rewriting pass was not recursively checking statements inside blocks, so inner blocks from if statements and nested block statements would be inferred to have an empty writeset. This is fixed using the new helper function in the rewriter pass.