### PR TITLE
Record parsing

### DIFF
--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -155,6 +155,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-record-1.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-record-1.ucl", 0)
   }
+  "test-record-3.ucl" should "verify successfully." in {
+    SMTLIB2Spec.expectedFails("./test/test-record-1.ucl", 0)
+  }
   "test-tuple-record-1.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-tuple-record-1.ucl", 0)
   }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -158,6 +158,9 @@ class BasicVerifierSpec extends AnyFlatSpec {
   "test-record-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-record-1.ucl", 0)
   }
+  "test-record-3.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-record-3.ucl", 0)
+  }
   "test-tuple-record-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-tuple-record-1.ucl", 0)
   }

--- a/test/test-record-3.ucl
+++ b/test/test-record-3.ucl
@@ -1,0 +1,21 @@
+module main {
+  type t = record {
+    x : integer
+  };
+  var x : t;
+
+  procedure foo()
+  	requires true;
+  	ensures x.x==0;
+    modifies x;
+  {
+    x.x = 0;
+  }
+
+  control{
+  	verify(foo);
+  	check;
+  	print_results;
+  }
+}
+


### PR DESCRIPTION
This fixes the first part of issue https://github.com/uclid-org/uclid/issues/99

The following did not parse because "x" is used as a record field and as a variable name
~~~
module main {
  type t = record {
    x : integer
  };
  var x : t;

  procedure foo()
    modifies x;
  {
    if (x.x == x.x) {
    }
  }
}
~~~
This is now added a test