### PR TITLE
UCLID: Add support for grounding of quantifiers over finite 'groups'

### DIFF
--- a/examples/finite_quant_example.ucl
+++ b/examples/finite_quant_example.ucl
@@ -1,0 +1,21 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    var hello : integer;
+
+    axiom test1 : finite_forall int in myGroup :: int < 2;
+
+    init {
+    }
+
+    next {
+    }
+
+    property acyclic : false;
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1445,12 +1445,13 @@ class SymbolicSimulator (module : Module) {
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
                Scope.FunctionArg(_, _) | Scope.Define(_, _, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _) =>
              false
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
+               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)             |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -204,6 +204,7 @@ object UclidMain {
     passManager.addPass(new BlockVariableRenamer())
     passManager.addPass(new BitVectorSliceFindWidth())
     passManager.addPass(new ExpressionTypeChecker())
+    passManager.addPass(new FiniteQuantsExpander())
     if (!test) passManager.addPass(new VerificationExpressionChecker())
     passManager.addPass(new PolymorphicTypeRewriter())
     passManager.addPass(new FindProcedureDependency())

--- a/src/main/scala/uclid/lang/ASTVistors.scala
+++ b/src/main/scala/uclid/lang/ASTVistors.scala
@@ -123,6 +123,7 @@ trait ReadOnlyPass[T] {
   def applyOnProcedureType(d : TraversalDirection.T, procT : ProcedureType, in : T, context : Scope) : T = { in }
   def applyOnArrayType(d : TraversalDirection.T, arrayT : ArrayType, in : T, context : Scope) : T = { in }
   def applyOnSynonymType(d : TraversalDirection.T, synT : SynonymType, in : T, context : Scope) : T = { in }
+  def applyOnGroupType(d : TraversalDirection.T, groupT : GroupType, in : T, context : Scope) : T = { in }
   def applyOnExternalType(d : TraversalDirection.T, extT : ExternalType, in : T, context : Scope) : T = { in }
   def applyOnModuleInstanceType(d : TraversalDirection.T, instT : ModuleInstanceType, in : T, context : Scope) : T = { in }
   def applyOnModuleType(d : TraversalDirection.T, modT : ModuleType, in : T, context : Scope) : T = { in }
@@ -163,6 +164,7 @@ trait ReadOnlyPass[T] {
   def applyOnLambda(d : TraversalDirection.T, lambda : Lambda, in : T, context : Scope) : T = { in }
   def applyOnExprDecorator(d : TraversalDirection.T, dec : ExprDecorator, in : T, context : Scope) : T = { in }
   def applyOnProcedureAnnotations(d : TraversalDirection.T, annot : ProcedureAnnotations, in : T, context : Scope) : T = { in }
+  def applyOnGroup(d : TraversalDirection.T, groupDecl : GroupDecl, in : T, context : Scope) : T = { in }
 }
 
 /* AST Visitor that rewrites and generates a new AST. */
@@ -211,6 +213,7 @@ trait RewritePass {
   def rewriteProcedureType(procT : ProcedureType, context : Scope) : Option[ProcedureType] = { Some(procT) }
   def rewriteArrayType(arrayT : ArrayType, context : Scope) : Option[ArrayType] = { Some(arrayT)  }
   def rewriteSynonymType(synT : SynonymType, context : Scope) : Option[Type] = { Some(synT)  }
+  def rewriteGroupType(groupT : GroupType, context : Scope) : Option[Type] = { Some(groupT) }
   def rewriteExternalType(extT : ExternalType, context : Scope) : Option[Type] = { Some(extT) }
   def rewriteModuleInstanceType(instT : ModuleInstanceType, context : Scope) : Option[ModuleInstanceType] = { Some(instT)  }
   def rewriteModuleType(modT : ModuleType, context : Scope) : Option[ModuleType] = { Some(modT)  }
@@ -323,6 +326,7 @@ class ASTAnalyzer[T] (_passName : String, _pass: ReadOnlyPass[T]) extends ASTAna
       case next : NextDecl => visitNext(next, result, context.withEnvironment(SequentialEnvironment))
       case spec : SpecDecl => visitSpec(spec, result, context)
       case axiom : AxiomDecl => visitAxiom(axiom, result, context)
+      case groupDecl : GroupDecl => visitGroup(groupDecl, result, context)
     }
     result = pass.applyOnDecl(TraversalDirection.Up, decl, result, context)
     return result
@@ -497,6 +501,17 @@ class ASTAnalyzer[T] (_passName : String, _pass: ReadOnlyPass[T]) extends ASTAna
     result = pass.applyOnAxiom(TraversalDirection.Up, axiom, result, context)
     return result
   }
+
+  def visitGroup(groupDecl : GroupDecl, in : T, context : Scope) : T = {
+    var result : T = in
+    result = pass.applyOnGroup(TraversalDirection.Down, groupDecl, result, context)
+    result = visitIdentifier(groupDecl.id, result, context)
+    result = visitType(groupDecl.typ, result, context)
+    result = groupDecl.members.foldLeft(result)((acc, member) => visitExpr(member, acc, context))
+    result = pass.applyOnGroup(TraversalDirection.Up, groupDecl, result, context)
+    return result
+  }
+
   def visitTypeDecl(typDec : TypeDecl, in : T, context : Scope) : T = {
     var result : T = in
     result = pass.applyOnTypeDecl(TraversalDirection.Down, typDec, result, context)
@@ -569,6 +584,7 @@ class ASTAnalyzer[T] (_passName : String, _pass: ReadOnlyPass[T]) extends ASTAna
       case extT : ExternalType => visitExternalType(extT, result, context)
       case instT : ModuleInstanceType => visitModuleInstanceType(instT, result, context)
       case modT : ModuleType => visitModuleType(modT, result, context)
+      case groupT : GroupType => visitGroupType(groupT, result, context)
     }
     result = pass.applyOnType(TraversalDirection.Up, typ, result, context)
     return result
@@ -662,6 +678,14 @@ class ASTAnalyzer[T] (_passName : String, _pass: ReadOnlyPass[T]) extends ASTAna
     result = pass.applyOnSynonymType(TraversalDirection.Up, synT, result, context)
     return result
   }
+
+  def visitGroupType(groupT : GroupType, in : T, context : Scope) : T = {
+    var result : T = in
+    result = pass.applyOnGroupType(TraversalDirection.Down, groupT, result, context)
+    result = pass.applyOnGroupType(TraversalDirection.Up, groupT, result, context)
+    return result
+  }
+
   def visitExternalType(extT : ExternalType, in : T, context : Scope) : T = {
     var result : T = in
     result = pass.applyOnExternalType(TraversalDirection.Down, extT, result, context)
@@ -1140,6 +1164,7 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
       case nextDecl : NextDecl => visitNext(nextDecl, context.withEnvironment(SequentialEnvironment))
       case specDecl : SpecDecl => visitSpec(specDecl, context)
       case axiomDecl : AxiomDecl => visitAxiom(axiomDecl, context)
+      case groupDecl : GroupDecl => visitGroup(groupDecl, context)
     }).flatMap(pass.rewriteDecl(_, context))
     return ASTNode.introducePos(setPosition, setFilename, declP, decl.position)
   }
@@ -1369,6 +1394,21 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
     val axiomP = exprP.flatMap((e) => pass.rewriteAxiom(AxiomDecl(idP, e, decsP), context))
     return ASTNode.introducePos(setPosition, setFilename, axiomP, axiom.position)
   }
+
+  def visitGroup(groupDecl : GroupDecl, context : Scope) : Option[GroupDecl] = {
+    val id = visitIdentifier(groupDecl.id, context)
+    val typ = visitType(groupDecl.typ, context)
+    val members = groupDecl.members.map((member) => pass.rewriteExpr(member, context)).flatten
+    val newGroupDecl =
+        if (id.isDefined && typ.isDefined) {
+            Some(GroupDecl(id.get, typ.get.asInstanceOf[GroupType], members))
+        } else {
+            None
+        }
+
+    return ASTNode.introducePos(setPosition, setFilename, newGroupDecl, groupDecl.position)
+  }
+
   def visitTypeDecl(typDec : TypeDecl, context : Scope) : Option[TypeDecl] = {
     val idP = visitIdentifier(typDec.id, context)
     val typeP = visitType(typDec.typ, context)
@@ -1429,6 +1469,7 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
       case extT : ExternalType => visitExternalType(extT, context)
       case instT : ModuleInstanceType => visitModuleInstanceType(instT, context)
       case modT : ModuleType => visitModuleType(modT, context)
+      case groupT : GroupType => visitGroupType(groupT, context)
     }).flatMap(pass.rewriteType(_, context))
     return ASTNode.introducePos(setPosition, setFilename, typP, typ.position)
   }
@@ -1516,6 +1557,11 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
     val idP = visitIdentifier(synT.id, context)
     val synTP = idP.flatMap(id => pass.rewriteSynonymType(SynonymType(id), context))
     return ASTNode.introducePos(setPosition, setFilename, synTP, synT.position)
+  }
+
+  def visitGroupType(groupT : GroupType, context : Scope) : Option[Type] = {
+    val groupTP = pass.rewriteGroupType(groupT, context)
+    return ASTNode.introducePos(setPosition, setFilename, groupTP, groupT.position)
   }
 
   def visitExternalType(extT : ExternalType, context : Scope) : Option[Type] = {

--- a/src/main/scala/uclid/lang/FiniteQuantsExpander.scala
+++ b/src/main/scala/uclid/lang/FiniteQuantsExpander.scala
@@ -1,0 +1,108 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2021 The Regents of the University of California
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Yatin Manerkar
+ *
+ * Class to expand finite quantifiers in UCLID ASTs.
+ *
+ */
+
+package uclid
+package lang
+
+class FiniteQuantsExpanderPass() extends RewritePass {
+  def expandFiniteQuant(id : Identifier, gId : Identifier, ctx : Scope, operands : List[Expr], isForall : Boolean) : Option[Expr] =
+  {
+    def flattenQuant(exprs : List[Expr], isForall : Boolean) : Expr =
+    {
+      if (isForall)
+      {
+          exprs.foldLeft[Expr](BoolLit(true))((a, b) => Operator.and(a, b))
+      }
+      else
+      {
+          exprs.foldLeft[Expr](BoolLit(false))((a, b) => Operator.or(a, b))
+      }
+    }
+
+    def replaceWithGroupElem(id : Identifier, elem : Expr, ctx : Scope, operand : Expr) : Expr =
+    {
+      val rewriteMap : Map[Expr, Expr] = Map(id -> elem)
+      val exprRewriter = new ExprRewriter("FiniteQuantRewriter", rewriteMap)
+      val result = exprRewriter.visitExpr(operand, ctx)
+      if(result.isEmpty)
+      {
+        throw new Utils.RuntimeError(
+            "Grounding finite quantifier %s with %s in %s results in a null expression??".format(id.toString, elem.toString, operand.toString))
+      }
+      else
+      {
+        result.get
+      }
+    }
+  
+    def expandFiniteQuantInner(id : Identifier, elems : List[Expr], ctx : Scope, operand : Expr, isForall : Boolean) : Expr =
+    {
+      flattenQuant(elems.map(replaceWithGroupElem(id, _, ctx, operand)), isForall)
+    }
+
+    //We should only be grounding a quantifier over a single expression, or something is seriously amiss.
+    assert(operands.length == 1);
+
+    //Get the elements of the group.
+    ctx.map.get(gId) match {
+      case Some(Scope.Group(_, _, elems)) =>
+        Some(flattenQuant(operands.map(expandFiniteQuantInner(id, elems, ctx, _, isForall)), isForall))
+      case _ => throw new Utils.RuntimeError("Could not find group %s".format(gId.toString))
+    }
+  }
+
+  override def rewriteOperatorApp(opapp : OperatorApplication, ctx : Scope) : Option[Expr] =
+  {
+    opapp match
+    {
+        case OperatorApplication(op, operands) =>
+            op match
+            {
+                case FiniteForallOp(id, gId) =>
+                    expandFiniteQuant(id, gId, ctx, operands, true)
+                case FiniteExistsOp(id, gId) =>
+                    expandFiniteQuant(id, gId, ctx, operands, false)
+                case _ =>
+                    Some(opapp)
+            }
+    }
+  }
+}
+
+class FiniteQuantsExpander extends ASTRewriter(
+    "FiniteQuantsExpander", new FiniteQuantsExpanderPass())

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -67,13 +67,14 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
         namedExpr match {
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _) =>
              false
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
                Scope.FunctionArg(_, _)    | Scope.Define(_, _, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
+               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)             |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |

--- a/src/main/scala/uclid/lang/Scope.scala
+++ b/src/main/scala/uclid/lang/Scope.scala
@@ -57,6 +57,7 @@ object Scope {
   case class ConstantLit(cId : Identifier, lit : NumericLit) extends ReadOnlyNamedExpression(cId, lit.typeOf)
   case class ConstantVar(cId : Identifier, cTyp : Type) extends ReadOnlyNamedExpression(cId, cTyp)
   case class Function(fId : Identifier, fTyp: Type) extends ReadOnlyNamedExpression(fId, fTyp)
+  case class Group(gId : Identifier, gTyp: Type, elems : List[Expr]) extends ReadOnlyNamedExpression(gId, gTyp)
   case class Grammar(gId : Identifier, gTyp : Type, nts : List[NonTerminal]) extends ReadOnlyNamedExpression(gId, gTyp)
   case class SynthesisFunction(fId : Identifier, fTyp: FunctionSig, gId: Option[Identifier], gargs: List[Identifier], conds : List[Expr]) extends ReadOnlyNamedExpression(fId, fTyp.typ)
   case class Define(dId : Identifier, dTyp : Type, defDecl: DefineDecl) extends ReadOnlyNamedExpression(dId, dTyp)
@@ -73,6 +74,7 @@ object Scope {
   case class SelectorField(fId : Identifier) extends ReadOnlyNamedExpression(fId, UndefinedType())
   case class ForallVar(vId : Identifier, vTyp : Type) extends ReadOnlyNamedExpression(vId, vTyp)
   case class ExistsVar(vId : Identifier, vTyp : Type) extends ReadOnlyNamedExpression(vId, vTyp)
+  case class GroupVar(vId : Identifier, vTyp : Type) extends ReadOnlyNamedExpression(vId, vTyp)
   case class VerifResultVar(vId : Identifier, cmd : GenericProofCommand) extends ReadOnlyNamedExpression(vId, UndefinedType())
 
   type IdentifierMap = Map[Identifier, NamedExpression]
@@ -275,6 +277,7 @@ case class Scope (
         case ModuleTypesImportDecl(_) | 
              ModuleDefinesImportDecl(_) | 
              InitDecl(_) | NextDecl(_)  => mapAcc
+        case GroupDecl(_, _, _) => mapAcc
       }
     }
     val m2 = m.decls.foldLeft(m1){(mapAcc, decl) =>
@@ -306,6 +309,7 @@ case class Scope (
         case SharedVarsDecl(_, typ) => Scope.addTypeToMap(mapAcc, typ, Some(m))
         case ConstantLitDecl(_, lit) => Scope.addTypeToMap(mapAcc, lit.typeOf, Some(m))
         case ConstantsDecl(_, typ) => Scope.addTypeToMap(mapAcc, typ, Some(m))
+        case GroupDecl(id, typ, elems) => Scope.addToMap(mapAcc, Scope.Group(id, typ, elems))
         case ModuleTypesImportDecl(_) | ModuleConstantsImportDecl(_) |
              ModuleFunctionsImportDecl(_) | ModuleDefinesImportDecl(_) |
              InstanceDecl(_, _, _, _, _) | SpecDecl(_, _, _) | 
@@ -345,6 +349,23 @@ case class Scope (
   }
   /** Return a new context with operator added. */
   def +(op : Operator) : Scope = {
+    def addGroupVar(id : Identifier, groupId : Identifier) : Scope = {
+      val groupTyp = typeOf(groupId)
+      if (groupTyp.isDefined) {
+        if (groupTyp.get.isInstanceOf[GroupType]) {
+          Scope(Scope.addToMap(map, Scope.GroupVar(id, groupTyp.get.asInstanceOf[GroupType].typ)), module, procedure, cmd, environment, Some(this))
+        } else {
+          Utils.raiseParsingError(
+            "Grounding a quantifier over %s, which is an element of type %s and not a group".format(groupId.toString, groupTyp.get.toString),
+            groupId.pos, groupId.filename)
+          this
+        }
+      } else {
+        Utils.raiseParsingError("Cannot find type of group %s".format(groupId.toString), groupId.pos, groupId.filename)
+        this
+      }
+    }
+
     op match {
       case ForallOp(vs, _) =>
         Scope(
@@ -352,8 +373,10 @@ case class Scope (
           module, procedure, cmd, environment, Some(this))
       case ExistsOp(vs, _) =>
         Scope(
-          vs.foldLeft(map)((mapAcc, arg) => Scope.addToMap(mapAcc, Scope.ForallVar(arg._1, arg._2))),
+          vs.foldLeft(map)((mapAcc, arg) => Scope.addToMap(mapAcc, Scope.ExistsVar(arg._1, arg._2))),
           module, procedure, cmd, environment, Some(this))
+      case FiniteForallOp(id, groupId) => addGroupVar(id, groupId)
+      case FiniteExistsOp(id, groupId) => addGroupVar(id, groupId)
       case sel : SelectorOperator =>
         addSelectorField(sel.ident)
       case _ => this

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -67,12 +67,13 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
                Scope.FunctionArg(_, _) | Scope.Define(_, _, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _)       =>
              false
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
+               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)          |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |
@@ -128,7 +129,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.VerifResultVar(_, _)     | Scope.FunctionArg(_, _)         |
                Scope.Define(_, _, _)          | Scope.Grammar(_, _, _)          |
                Scope.ConstantLit(_, _)        | Scope.BlockVar(_, _)            |
-               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          =>
+               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          |
+               Scope.Group(_, _, _)           | Scope.GroupVar(_, _) =>
               id
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.SynthesisFunction(_, _, _, _, _) =>
              ExternalIdentifier(moduleName, id)

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -397,7 +397,19 @@ class ExpressionTypeCheckerPass extends ReadOnlyPass[Set[Utils.TypeError]]
         }
         case qOp : QuantifiedBooleanOperator => {
           checkTypeError(argTypes(0).isInstanceOf[BooleanType], "Operand to the quantifier '" + qOp.toString + "' must be boolean", opapp.pos, c.filename)
-          BooleanType()
+
+          qOp match {
+            case FiniteForallOp(_, groupId) =>
+              val typ = c.typeOf(groupId)
+
+              checkTypeError(typ.isDefined && typ.get.isInstanceOf[GroupType], "finite_forall must be over a group", opapp.pos, c.filename)
+              BooleanType()
+            case FiniteExistsOp(_, groupId) =>
+              val typ = c.typeOf(groupId)
+              checkTypeError(typ.isDefined && typ.get.isInstanceOf[GroupType], "finite_exists must be over a group", opapp.pos, c.filename)
+              BooleanType()
+            case _ => BooleanType()
+          }
         }
         case boolOp : BooleanOperator => {
           boolOp match {

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -368,6 +368,15 @@ case class ExistsOp(vs: List[(Identifier, Type)], patterns: List[List[Expr]]) ex
   override def variables = vs
 }
 
+case class FiniteForallOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+  override def variables = List.empty
+  override def toString = QuantifiedBooleanOperator.toString("finite_forall", List.empty, List.empty)
+}
+case class FiniteExistsOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+  override def toString = QuantifiedBooleanOperator.toString("finite_exists", List.empty, List.empty)
+  override def variables = List.empty
+}
+
 // (In-)equality operators.
 sealed abstract class ComparisonOperator() extends Operator {
   override def fixity = Operator.INFIX
@@ -590,7 +599,7 @@ case class OperatorApplication(op: Operator, operands: List[Expr]) extends Possi
         operands(0).toString + "." + i.toString
       case SelectFromInstance(f) =>
         operands(0).toString + "." + f.toString
-      case ForallOp(_, _) | ExistsOp(_, _) =>
+      case ForallOp(_, _) | ExistsOp(_, _) | FiniteForallOp(_, _) | FiniteExistsOp(_, _) =>
         "(" + op.toString + operands(0).toString + ")"
       case _ =>
         if (op.fixity == Operator.INFIX) {
@@ -845,6 +854,11 @@ case class SynonymType(id: Identifier) extends Type {
     case _ => false
   }
 }
+
+case class GroupType(typ : Type) extends Type {
+  override def toString = "group (" + typ.toString + ")"
+}
+
 case class ExternalType(moduleId : Identifier, typeId : Identifier) extends Type {
   override def toString = moduleId.toString + "." + typeId.toString
 }
@@ -1244,6 +1258,10 @@ case class DefineDecl(id: Identifier, sig: FunctionSig, expr: Expr) extends Decl
 case class ModuleDefinesImportDecl(id: Identifier) extends Decl {
   override def toString = "define * = $s.*; // %s".format(id.toString)
   override def declNames = List.empty
+}
+case class GroupDecl(id: Identifier, typ : GroupType, members: List[Expr]) extends Decl {
+  override def toString = "define %s : %s = %s;".format(id.toString, typ.toString, members.toString)
+  override def declNames = List(id)
 }
 
 sealed abstract class GrammarTerm extends ASTNode

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -160,6 +160,8 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwControl = "control"
     lazy val KwForall = "forall"
     lazy val KwExists = "exists"
+    lazy val KwFiniteForall = "finite_forall"
+    lazy val KwFiniteExists = "finite_exists"
     lazy val KwDefault = "default"
     lazy val KwSynthesis = "synthesis"
     lazy val KwGrammar = "grammar"
@@ -174,6 +176,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwHyperProperty = "hyperproperty"
     lazy val KwHyperInvariant = "hyperinvariant"
     lazy val KwHyperAxiom = "hyperaxiom"
+    lazy val KwGroup = "group"
     // lazy val TemporalOpGlobally = "G"
     // lazy val TemporalOpFinally = "F"
     // lazy val TemporalOpNext = "Next"
@@ -195,7 +198,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       KwInstance, KwInput, KwOutput, KwConst, KwModule, KwType, KwEnum,
       KwRecord, KwSkip, KwDefine, KwFunction, KwControl, KwInit,
       KwNext, KwLambda, KwModifies, KwProperty, KwDefineAxiom,
-      KwForall, KwExists, KwDefault, KwSynthesis, KwGrammar, KwRequires,
+      KwForall, KwExists, KwFiniteForall, KwFiniteExists, KwGroup, KwDefault, KwSynthesis, KwGrammar, KwRequires,
       KwEnsures, KwInvariant, KwParameter, 
       KwHyperProperty, KwHyperInvariant, KwHyperAxiom)
 
@@ -308,6 +311,16 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
             }
           }
         } |
+      KwFiniteForall ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+        case id ~ groupId ~ expr => {
+          OperatorApplication(FiniteForallOp(id, groupId), List(expr))
+        }
+      } |
+      KwFiniteExists ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+        case id ~ groupId ~ expr => {
+          OperatorApplication(FiniteExistsOp(id, groupId), List(expr))
+        }
+      } |
       E3
 
     /** E3 = E4 OpEquiv E3 | E4  **/
@@ -760,13 +773,22 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       }
     }
 
+    lazy val GroupDecl : PackratParser[lang.GroupDecl] = positioned {
+      KwGroup ~> Id ~ (":" ~> Type) ~ ("=" ~ "{" ~> CommaSeparatedExprList) <~ "}" ~ ";" ^^
+      {
+        case id ~ gType ~ gElems => {
+          lang.GroupDecl(id, lang.GroupType(gType), gElems)
+        }
+      }
+    }
+
     lazy val Decl: PackratParser[Decl] =
       positioned (InstanceDecl | TypeDecl | ConstDecl | FuncDecl |
                   ModuleTypesImportDecl | ModuleFuncsImportDecl | ModuleConstsImportDecl |
                   SynthFuncDecl | DefineDecl | ModuleDefsImportDecl | GrammarDecl |
                   VarsDecl | InputsDecl | OutputsDecl | SharedVarsDecl |
                   ConstLitDecl | ConstDecl | ProcedureDecl |
-                  InitDecl | NextDecl | SpecDecl | AxiomDecl)
+                  InitDecl | NextDecl | SpecDecl | AxiomDecl | GroupDecl)
 
     // control commands.
     lazy val CmdParam : PackratParser[lang.CommandParams] = 

--- a/src/main/scala/uclid/smt/Converter.scala
+++ b/src/main/scala/uclid/smt/Converter.scala
@@ -68,7 +68,7 @@ object Converter {
       case lang.SynonymType(_) =>
         throw new Utils.UnimplementedException("Synonym types must have been eliminated by now.")
       case lang.UndefinedType() | lang.ProcedureType(_, _) | lang.ExternalType(_, _) |
-           lang.ModuleInstanceType(_) | lang.ModuleType(_, _, _, _, _, _, _, _) =>
+           lang.ModuleInstanceType(_) | lang.ModuleType(_, _, _, _, _, _, _, _) | lang.GroupType(_) =>
         throw new AssertionError("Type '" + typ.toString + "' not expected here.")
     }
   }


### PR DESCRIPTION
Add support for elements of type "group", and "finite_forall" and
"finite_exists" quantifiers over those groups.