### PR TITLE
UCLID: Add support for grounding of quantifiers over finite 'groups'

### DIFF
--- a/examples/finite_quant_example.ucl
+++ b/examples/finite_quant_example.ucl
@@ -1,0 +1,21 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    var hello : integer;
+
+    axiom test1 : finite_forall int in myGroup :: int < 2;
+
+    init {
+    }
+
+    next {
+    }
+
+    property acyclic : false;
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1460,13 +1460,13 @@ class SymbolicSimulator (module : Module) {
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
                Scope.FunctionArg(_, _) | Scope.Define(_, _, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _) =>
              false
-          case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
-               Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
-               Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
-               Scope.OracleFunction(_, _, _) =>
+          case Scope.ConstantVar(_, _)      | Scope.Function(_, _)       |
+               Scope.LambdaVar(_ , _)       | Scope.ForallVar(_, _)      |
+               Scope.ExistsVar(_, _)        | Scope.EnumIdentifier(_, _) |
+               Scope.ConstantLit(_, _)      | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.OracleFunction(_, _, _)| Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)             |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -242,8 +242,6 @@ object UclidMain {
     passManager.addPass(new BitVectorSliceFindWidth())
     // the big type checker 
     passManager.addPass(new ExpressionTypeChecker())
-    // Expands (grounds) finite_forall and finite_exists quantifiers
-    passManager.addPass(new FiniteQuantsExpander())
     // test flag is default false
     // checks if prime/old/history are used in the incorrect places
     if (!test) passManager.addPass(new VerificationExpressionChecker())
@@ -350,6 +348,8 @@ object UclidMain {
     passManager.addPass(new ModuleFlattener(mainModuleName))
     // gets rid of modules apart from main
     passManager.addPass(new ModuleEliminator(mainModuleName))
+    // Expands (grounds) finite_forall and finite_exists quantifiers
+    passManager.addPass(new FiniteQuantsExpander())
     passManager.addPass(new LTLOperatorRewriter())
     passManager.addPass(new LTLPropertyRewriter())
     passManager.addPass(new Optimizer())

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -242,6 +242,8 @@ object UclidMain {
     passManager.addPass(new BitVectorSliceFindWidth())
     // the big type checker 
     passManager.addPass(new ExpressionTypeChecker())
+    // Expands (grounds) finite_forall and finite_exists quantifiers
+    passManager.addPass(new FiniteQuantsExpander())
     // test flag is default false
     // checks if prime/old/history are used in the incorrect places
     if (!test) passManager.addPass(new VerificationExpressionChecker())

--- a/src/main/scala/uclid/lang/FiniteQuantsExpander.scala
+++ b/src/main/scala/uclid/lang/FiniteQuantsExpander.scala
@@ -1,0 +1,108 @@
+/*
+ * UCLID5 Verification and Synthesis Engine
+ *
+ * Copyright (c) 2021 The Regents of the University of California
+ *
+ * All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ *
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Yatin Manerkar
+ *
+ * Class to expand finite quantifiers in UCLID ASTs.
+ *
+ */
+
+package uclid
+package lang
+
+class FiniteQuantsExpanderPass() extends RewritePass {
+  def expandFiniteQuant(id : Identifier, gId : Identifier, ctx : Scope, operands : List[Expr], isForall : Boolean) : Option[Expr] =
+  {
+    def flattenQuant(exprs : List[Expr], isForall : Boolean) : Expr =
+    {
+      if (isForall)
+      {
+          exprs.foldLeft[Expr](BoolLit(true))((a, b) => Operator.and(a, b))
+      }
+      else
+      {
+          exprs.foldLeft[Expr](BoolLit(false))((a, b) => Operator.or(a, b))
+      }
+    }
+
+    def replaceWithGroupElem(id : Identifier, elem : Expr, ctx : Scope, operand : Expr) : Expr =
+    {
+      val rewriteMap : Map[Expr, Expr] = Map(id -> elem)
+      val exprRewriter = new ExprRewriter("FiniteQuantRewriter", rewriteMap)
+      val result = exprRewriter.visitExpr(operand, ctx)
+      if(result.isEmpty)
+      {
+        throw new Utils.RuntimeError(
+            "Grounding finite quantifier %s with %s in %s results in a null expression??".format(id.toString, elem.toString, operand.toString))
+      }
+      else
+      {
+        result.get
+      }
+    }
+  
+    def expandFiniteQuantInner(id : Identifier, elems : List[Expr], ctx : Scope, operand : Expr, isForall : Boolean) : Expr =
+    {
+      flattenQuant(elems.map(replaceWithGroupElem(id, _, ctx, operand)), isForall)
+    }
+
+    //We should only be grounding a quantifier over a single expression, or something is seriously amiss.
+    assert(operands.length == 1);
+
+    //Get the elements of the group.
+    ctx.map.get(gId) match {
+      case Some(Scope.Group(_, _, elems)) =>
+        Some(flattenQuant(operands.map(expandFiniteQuantInner(id, elems, ctx, _, isForall)), isForall))
+      case _ => throw new Utils.RuntimeError("Could not find group %s".format(gId.toString))
+    }
+  }
+
+  override def rewriteOperatorApp(opapp : OperatorApplication, ctx : Scope) : Option[Expr] =
+  {
+    opapp match
+    {
+        case OperatorApplication(op, operands) =>
+            op match
+            {
+                case FiniteForallOp(id, gId) =>
+                    expandFiniteQuant(id, gId, ctx, operands, true)
+                case FiniteExistsOp(id, gId) =>
+                    expandFiniteQuant(id, gId, ctx, operands, false)
+                case _ =>
+                    Some(opapp)
+            }
+    }
+  }
+}
+
+class FiniteQuantsExpander extends ASTRewriter(
+    "FiniteQuantsExpander", new FiniteQuantsExpanderPass())

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -67,14 +67,14 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
         namedExpr match {
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _) =>
              false
-          case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
-               Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
-               Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
-               Scope.FunctionArg(_, _)    | Scope.Define(_, _, _) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
-               Scope.OracleFunction(_, _, _) =>
+          case Scope.ConstantVar(_, _)      | Scope.Function(_, _)       |
+               Scope.LambdaVar(_ , _)       | Scope.ForallVar(_, _)      |
+               Scope.ExistsVar(_, _)        | Scope.EnumIdentifier(_, _) |
+               Scope.FunctionArg(_, _)      | Scope.Define(_, _, _) |
+               Scope.ConstantLit(_, _)      | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.OracleFunction(_, _, _)| Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)          |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |

--- a/src/main/scala/uclid/lang/ModuleTypeChecker.scala
+++ b/src/main/scala/uclid/lang/ModuleTypeChecker.scala
@@ -254,6 +254,38 @@ class ModuleTypeCheckerPass extends ReadOnlyPass[Set[ModuleError]]
       in
     }
   }
+
+  override def applyOnGroup(d : TraversalDirection.T, groupDecl : GroupDecl, in : T, context : Scope) : T = {
+    val groupElemType = 
+      groupDecl.typ match {
+        case GroupType(typ) => typ
+        case _ => throw new Utils.RuntimeError("GroupDecl does not have type GroupType?")
+      }
+
+    def checkGroupTypes(errors : T, expr : Expr) : T =
+    {
+      val exprType = exprTypeChecker.typeOf(expr, context)
+
+      if (exprType != groupDecl.typ.typ)
+      {
+        val error = ModuleError("Expected member of group type %s but found member of type %s".format(groupDecl.typ.typ.toString, exprType.toString), expr.position)
+        errors + error
+      }
+      else
+      {
+        errors
+      }
+    }
+
+    var ret = in
+    
+    if (d == TraversalDirection.Down) {
+      ret = groupDecl.members.foldLeft(ret)(checkGroupTypes)
+    }
+
+    ret
+  }
+
   override def applyOnModuleTypesImport(d : TraversalDirection.T, modTypImport : ModuleTypesImportDecl, in : T, context : Scope) : T = {
     if (d == TraversalDirection.Down) {
       val id = modTypImport.id

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -67,13 +67,14 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
           case Scope.StateVar(_, _)    | Scope.InputVar(_, _)  |
                Scope.OutputVar(_, _)   | Scope.SharedVar(_, _) |
                Scope.FunctionArg(_, _) | Scope.Define(_, _, _) |
-               Scope.Instance(_)       =>
+               Scope.Instance(_)       | Scope.Group(_, _, _)       =>
              false
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)       |
                Scope.LambdaVar(_ , _)     | Scope.ForallVar(_, _)      |
                Scope.ExistsVar(_, _)      | Scope.EnumIdentifier(_, _) |
                Scope.OracleFunction(_,_,_) |
-               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) =>
+               Scope.ConstantLit(_, _)    | Scope.SynthesisFunction(_, _, _, _, _) |
+               Scope.GroupVar(_, _) =>
              true
           case Scope.ModuleDefinition(_)      | Scope.Grammar(_, _, _)          |
                Scope.TypeSynonym(_, _)        | Scope.Procedure(_, _)           |
@@ -131,6 +132,7 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.Define(_, _, _)          | Scope.Grammar(_, _, _)          |
                Scope.ConstantLit(_, _)        | Scope.BlockVar(_, _)            |
                Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          |
+               Scope.Group(_, _, _)           | Scope.GroupVar(_, _)            |
                Scope.Macro(_, _, _)           =>
               id
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.OracleFunction(_,_,_) | Scope.SynthesisFunction(_, _, _, _, _) =>

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -102,6 +102,8 @@ class TypeSynonymFinderPass extends ReadOnlyPass[Unit]
         MapType(inTypes.map(simplifyType(_, visited, m)), simplifyType(outType, visited, m))
       case ArrayType(inTypes, outType) =>
         ArrayType(inTypes.map(simplifyType(_, visited, m)), simplifyType(outType, visited, m))
+      case GroupType(gTyp) =>
+        GroupType(simplifyType(gTyp, visited, m))
       case _ =>
         typ
     }
@@ -137,6 +139,13 @@ class TypeSynonymRewriterPass extends RewritePass {
   override def rewriteType(typ : Type, ctx : Scope) : Option[Type] = {
     val result = typ match {
       case SynonymType(name) => typeSynonymFinderPass.typeDeclMap.get(name)
+      case GroupType(SynonymType(name)) =>
+        val realName = typeSynonymFinderPass.typeDeclMap.get(name)
+        if (realName.isDefined) {
+            Some(GroupType(realName.get))
+        } else {
+            Some(typ) //Undefined synonym types are checked for in validateSynonyms(..).
+        }
       case _ => Some(typ)
     }
     return result

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -397,7 +397,19 @@ class ExpressionTypeCheckerPass extends ReadOnlyPass[Set[Utils.TypeError]]
         }
         case qOp : QuantifiedBooleanOperator => {
           checkTypeError(argTypes(0).isInstanceOf[BooleanType], "Operand to the quantifier '" + qOp.toString + "' must be boolean", opapp.pos, c.filename)
-          BooleanType()
+
+          qOp match {
+            case FiniteForallOp(_, groupId) =>
+              val typ = c.typeOf(groupId)
+
+              checkTypeError(typ.isDefined && typ.get.isInstanceOf[GroupType], "finite_forall must be over a group", opapp.pos, c.filename)
+              BooleanType()
+            case FiniteExistsOp(_, groupId) =>
+              val typ = c.typeOf(groupId)
+              checkTypeError(typ.isDefined && typ.get.isInstanceOf[GroupType], "finite_exists must be over a group", opapp.pos, c.filename)
+              BooleanType()
+            case _ => BooleanType()
+          }
         }
         case boolOp : BooleanOperator => {
           boolOp match {

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -368,11 +368,11 @@ case class ExistsOp(vs: List[(Identifier, Type)], patterns: List[List[Expr]]) ex
   override def variables = vs
 }
 
-case class FiniteForallOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+case class FiniteForallOp(id : (Identifier, Type), groupId : Identifier) extends QuantifiedBooleanOperator {
   override def variables = List.empty
   override def toString = QuantifiedBooleanOperator.toString("finite_forall", List.empty, List.empty)
 }
-case class FiniteExistsOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+case class FiniteExistsOp(id : (Identifier, Type), groupId : Identifier) extends QuantifiedBooleanOperator {
   override def toString = QuantifiedBooleanOperator.toString("finite_exists", List.empty, List.empty)
   override def variables = List.empty
 }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -368,6 +368,15 @@ case class ExistsOp(vs: List[(Identifier, Type)], patterns: List[List[Expr]]) ex
   override def variables = vs
 }
 
+case class FiniteForallOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+  override def variables = List.empty
+  override def toString = QuantifiedBooleanOperator.toString("finite_forall", List.empty, List.empty)
+}
+case class FiniteExistsOp(id : Identifier, groupId : Identifier) extends QuantifiedBooleanOperator {
+  override def toString = QuantifiedBooleanOperator.toString("finite_exists", List.empty, List.empty)
+  override def variables = List.empty
+}
+
 // (In-)equality operators.
 sealed abstract class ComparisonOperator() extends Operator {
   override def fixity = Operator.INFIX
@@ -590,7 +599,7 @@ case class OperatorApplication(op: Operator, operands: List[Expr]) extends Possi
         operands(0).toString + "." + i.toString
       case SelectFromInstance(f) =>
         operands(0).toString + "." + f.toString
-      case ForallOp(_, _) | ExistsOp(_, _) =>
+      case ForallOp(_, _) | ExistsOp(_, _) | FiniteForallOp(_, _) | FiniteExistsOp(_, _) =>
         "(" + op.toString + operands(0).toString + ")"
       case _ =>
         if (op.fixity == Operator.INFIX) {
@@ -845,6 +854,11 @@ case class SynonymType(id: Identifier) extends Type {
     case _ => false
   }
 }
+
+case class GroupType(typ : Type) extends Type {
+  override def toString = "group (" + typ.toString + ")"
+}
+
 case class ExternalType(moduleId : Identifier, typeId : Identifier) extends Type {
   override def toString = moduleId.toString + "." + typeId.toString
 }
@@ -1259,6 +1273,10 @@ case class MacroDecl(id: Identifier, sig: FunctionSig, body: Statement) extends 
 case class ModuleDefinesImportDecl(id: Identifier) extends Decl {
   override def toString = "define * = $s.*; // %s".format(id.toString)
   override def declNames = List.empty
+}
+case class GroupDecl(id: Identifier, typ : GroupType, members: List[Expr]) extends Decl {
+  override def toString = "define %s : %s = %s;".format(id.toString, typ.toString, members.toString)
+  override def declNames = List(id)
 }
 
 sealed abstract class GrammarTerm extends ASTNode

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -314,12 +314,12 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
             }
           }
         } |
-      KwFiniteForall ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+      KwFiniteForall ~ "(" ~> (IdType <~ ")") ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
         case id ~ groupId ~ expr => {
           OperatorApplication(FiniteForallOp(id, groupId), List(expr))
         }
       } |
-      KwFiniteExists ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+      KwFiniteExists ~ "(" ~> (IdType <~ ")") ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
         case id ~ groupId ~ expr => {
           OperatorApplication(FiniteExistsOp(id, groupId), List(expr))
         }
@@ -425,12 +425,15 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val ArrayType : PackratParser[lang.ArrayType] = positioned {
       ("[") ~> Type ~ (rep ("," ~> Type) <~ "]") ~ Type ^^ { case t ~ ts ~ rt => lang.ArrayType(t :: ts, rt)}
     }
+    lazy val GroupType : PackratParser[lang.GroupType] = positioned {
+      KwGroup ~ "(" ~> Type <~ ")" ^^ { case t => lang.GroupType(t)}
+    }
     lazy val SynonymType : PackratParser[lang.SynonymType] = positioned ( Id ^^ { case id => lang.SynonymType(id) } )
     lazy val ExternalType : PackratParser[lang.ExternalType] = positioned {
       Id ~ ("." ~> Id) ^^ { case moduleId ~ typeId => lang.ExternalType(moduleId, typeId) }
     }
     lazy val Type : PackratParser[Type] = positioned {
-      MapType | ArrayType | EnumType | TupleType | RecordType | ExternalType | SynonymType | PrimitiveType
+      MapType | ArrayType | EnumType | TupleType | RecordType | ExternalType | SynonymType | PrimitiveType | GroupType
     }
 
     lazy val IdType : PackratParser[(Identifier,Type)] =

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -162,6 +162,8 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwControl = "control"
     lazy val KwForall = "forall"
     lazy val KwExists = "exists"
+    lazy val KwFiniteForall = "finite_forall"
+    lazy val KwFiniteExists = "finite_exists"
     lazy val KwDefault = "default"
     lazy val KwSynthesis = "synthesis"
     lazy val KwGrammar = "grammar"
@@ -177,6 +179,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwHyperInvariant = "hyperinvariant"
     lazy val KwHyperAxiom = "hyperaxiom"
     lazy val KwMacro = "macro"
+    lazy val KwGroup = "group"
     // lazy val TemporalOpGlobally = "G"
     // lazy val TemporalOpFinally = "F"
     // lazy val TemporalOpNext = "Next"
@@ -198,7 +201,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       KwInstance, KwInput, KwOutput, KwConst, KwModule, KwType, KwEnum,
       KwRecord, KwSkip, KwDefine, KwFunction, KwOracle, KwControl, KwInit,
       KwNext, KwLambda, KwModifies, KwProperty, KwDefineAxiom,
-      KwForall, KwExists, KwDefault, KwSynthesis, KwGrammar, KwRequires,
+      KwForall, KwExists, KwFiniteForall, KwFiniteExists, KwGroup, KwDefault, KwSynthesis, KwGrammar, KwRequires,
       KwEnsures, KwInvariant, KwParameter, 
       KwHyperProperty, KwHyperInvariant, KwHyperAxiom, KwMacro)
 
@@ -311,6 +314,16 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
             }
           }
         } |
+      KwFiniteForall ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+        case id ~ groupId ~ expr => {
+          OperatorApplication(FiniteForallOp(id, groupId), List(expr))
+        }
+      } |
+      KwFiniteExists ~> Id ~ (KwIn ~> Id) ~ ("::" ~> E1) ^^ {
+        case id ~ groupId ~ expr => {
+          OperatorApplication(FiniteExistsOp(id, groupId), List(expr))
+        }
+      } |
       E3
 
     /** E3 = E4 OpEquiv E3 | E4  **/
@@ -780,6 +793,15 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       }
     }
 
+    lazy val GroupDecl : PackratParser[lang.GroupDecl] = positioned {
+      KwGroup ~> Id ~ (":" ~> Type) ~ ("=" ~ "{" ~> CommaSeparatedExprList) <~ "}" ~ ";" ^^
+      {
+        case id ~ gType ~ gElems => {
+          lang.GroupDecl(id, lang.GroupType(gType), gElems)
+        }
+      }
+    }
+
     lazy val Decl: PackratParser[Decl] =
       positioned (InstanceDecl | TypeDecl | ConstDecl | FuncDecl | OracleFuncDecl |
                   ModuleTypesImportDecl | ModuleFuncsImportDecl | ModuleConstsImportDecl |
@@ -787,7 +809,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
                   VarsDecl | InputsDecl | OutputsDecl | SharedVarsDecl |
                   ConstLitDecl | ConstDecl | ProcedureDecl |
                   InitDecl | NextDecl | SpecDecl | AxiomDecl |
-                  ModuleImportDecl | MacroDecl)
+                  ModuleImportDecl | MacroDecl | GroupDecl)
 
     // control commands.
     lazy val CmdParam : PackratParser[lang.CommandParams] = 

--- a/src/main/scala/uclid/smt/Converter.scala
+++ b/src/main/scala/uclid/smt/Converter.scala
@@ -68,7 +68,7 @@ object Converter {
       case lang.SynonymType(_) =>
         throw new Utils.UnimplementedException("Synonym types must have been eliminated by now.")
       case lang.UndefinedType() | lang.ProcedureType(_, _) | lang.ExternalType(_, _) |
-           lang.ModuleInstanceType(_) | lang.ModuleType(_, _, _, _, _, _, _, _) =>
+           lang.ModuleInstanceType(_) | lang.ModuleType(_, _, _, _, _, _, _, _) | lang.GroupType(_) =>
         throw new AssertionError("Type '" + typ.toString + "' not expected here.")
     }
   }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -837,5 +837,19 @@ class ParserSpec extends AnyFlatSpec {
         assert (p.errors.exists(p => p._1.contains("Macro calls are not allowed in the next block")))
     }
   }
+  "test-group-parse-0.ucl" should "not parse successfully" in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-group-parse-0.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.TypeErrorList => assert (true)
+      case _: Throwable => assert (false)
+    }
+  }
+  "test-group-parse-1.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-group-parse-1.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
 
 }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -381,6 +381,9 @@ class GroupVerifSpec extends AnyFlatSpec {
   "test-group-2.ucl" should "verify one and fail one assertion." in {
     VerifierSpec.expectedFails("./test/test-group-2.ucl", 1)
   }
+  "test-group-3.ucl" should "verify one and fail one assertion." in {
+    VerifierSpec.expectedFails("./test/test-group-3.ucl", 1)
+  }
 }
 class ModuleVerifSpec extends AnyFlatSpec {
   "test-modules.ucl" should "verify all assertions." in {

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -371,6 +371,17 @@ class QuantifierVerifSpec extends AnyFlatSpec {
     VerifierSpec.expectedFails("./test/test-exists-0.ucl", 0)
   }
 }
+class GroupVerifSpec extends AnyFlatSpec {
+  "test-group-0.ucl" should "verify one and fail one assertion." in {
+    VerifierSpec.expectedFails("./test/test-group-0.ucl", 1)
+  }
+  "test-group-1.ucl" should "verify one and fail one assertion." in {
+    VerifierSpec.expectedFails("./test/test-group-1.ucl", 1)
+  }
+  "test-group-2.ucl" should "verify one and fail one assertion." in {
+    VerifierSpec.expectedFails("./test/test-group-2.ucl", 1)
+  }
+}
 class ModuleVerifSpec extends AnyFlatSpec {
   "test-modules.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-modules.ucl", 0)

--- a/test/test-group-0.ucl
+++ b/test/test-group-0.ucl
@@ -1,8 +1,8 @@
 module main {
     group myGroup : integer = {0, 1, 2, 3};
 
-    property test1 : finite_forall int in myGroup :: int < 4; //Should pass
-    property test2 : finite_forall int in myGroup :: int < 2; //Should fail
+    property test1 : finite_forall (int : integer) in myGroup :: int < 4; //Should pass
+    property test2 : finite_forall (int : integer) in myGroup :: int < 2; //Should fail
 
     init {
     }

--- a/test/test-group-0.ucl
+++ b/test/test-group-0.ucl
@@ -1,0 +1,18 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    property test1 : finite_forall int in myGroup :: int < 4; //Should pass
+    property test2 : finite_forall int in myGroup :: int < 2; //Should fail
+
+    init {
+    }
+
+    next {
+    }
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-1.ucl
+++ b/test/test-group-1.ucl
@@ -1,8 +1,8 @@
 module main {
     group myGroup : integer = {0, 1, 2, 3};
 
-    property test1 : finite_exists int in myGroup :: int < 2; //Should pass
-    property test2 : finite_exists int in myGroup :: int > 3; //Should fail
+    property test1 : finite_exists (int : integer) in myGroup :: int < 2; //Should pass
+    property test2 : finite_exists (int : integer) in myGroup :: int > 3; //Should fail
 
     init {
     }

--- a/test/test-group-1.ucl
+++ b/test/test-group-1.ucl
@@ -1,0 +1,18 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    property test1 : finite_exists int in myGroup :: int < 2; //Should pass
+    property test2 : finite_exists int in myGroup :: int > 3; //Should fail
+
+    init {
+    }
+
+    next {
+    }
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-2.ucl
+++ b/test/test-group-2.ucl
@@ -1,0 +1,24 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+    group myGroup2 : integer = {4, 5, 6, 7};
+
+    //Should pass
+    property test1 : finite_forall int1 in myGroup ::
+                        finite_exists int2 in myGroup :: int1 == int2;
+
+    //Should fail.
+    property test2 : finite_forall int1 in myGroup ::
+                        finite_exists int2 in myGroup2 :: int1 == int2;
+
+    init {
+    }
+
+    next {
+    }
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-2.ucl
+++ b/test/test-group-2.ucl
@@ -3,12 +3,12 @@ module main {
     group myGroup2 : integer = {4, 5, 6, 7};
 
     //Should pass
-    property test1 : finite_forall int1 in myGroup ::
-                        finite_exists int2 in myGroup :: int1 == int2;
+    property test1 : finite_forall (int1 : integer) in myGroup ::
+                        finite_exists (int2 : integer) in myGroup :: int1 == int2;
 
     //Should fail.
-    property test2 : finite_forall int1 in myGroup ::
-                        finite_exists int2 in myGroup2 :: int1 == int2;
+    property test2 : finite_forall (int1 : integer) in myGroup ::
+                        finite_exists (int2 : integer) in myGroup2 :: int1 == int2;
 
     init {
     }

--- a/test/test-group-3.ucl
+++ b/test/test-group-3.ucl
@@ -1,0 +1,20 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    define allGreaterThan(grp : group(integer), i : integer) : boolean = finite_forall (int : integer) in grp :: int > i;
+
+    property test1 : allGreaterThan(myGroup, -1); //Should pass
+    property test2 : allGreaterThan(myGroup, 2); //Should fail
+
+    init {
+    }
+
+    next {
+    }
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-parse-0.ucl
+++ b/test/test-group-parse-0.ucl
@@ -3,7 +3,7 @@ module main {
 
     var hello : boolean;
 
-    axiom test1 : finite_forall int in myGroup :: int < hello; // Should throw a type error.
+    axiom test1 : finite_forall (int : integer) in myGroup :: int < hello; // Should throw a type error.
 
     init {
     }

--- a/test/test-group-parse-0.ucl
+++ b/test/test-group-parse-0.ucl
@@ -1,0 +1,21 @@
+module main {
+    group myGroup : integer = {0, 1, 2, 3};
+
+    var hello : boolean;
+
+    axiom test1 : finite_forall int in myGroup :: int < hello; // Should throw a type error.
+
+    init {
+    }
+
+    next {
+    }
+
+    property acyclic : false;
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-parse-1.ucl
+++ b/test/test-group-parse-1.ucl
@@ -1,0 +1,23 @@
+//This test was created by @polgreen.
+module main {
+
+    type t = integer;
+    var a,b,c,d : t;
+    group myGroup : t = {a,b,c,d};
+
+    axiom test1 : finite_forall thing in myGroup :: thing < 2;
+
+    init {
+    }
+
+    next {
+    }
+
+    property acyclic : false;
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-group-parse-1.ucl
+++ b/test/test-group-parse-1.ucl
@@ -5,7 +5,7 @@ module main {
     var a,b,c,d : t;
     group myGroup : t = {a,b,c,d};
 
-    axiom test1 : finite_forall thing in myGroup :: thing < 2;
+    axiom test1 : finite_forall (thing : integer) in myGroup :: thing < 2;
 
     init {
     }


### PR DESCRIPTION
Add support for elements of type "group", and "finite_forall" and
"finite_exists" quantifiers over those groups.