### PR TITLE
Add chaining for subtract, multiply and divide operators

### DIFF
--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -344,9 +344,9 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     /** E8 = E9 OpAdd E8 | E9 **/
     lazy val E8: PackratParser[Expr] = positioned ( E9 ~ OpAdd ~ E8 ^^ ast_binary | E9 )
     /** E9 = E9 OpSub E10 | E10 **/
-    lazy val E9: PackratParser[Expr] = positioned ( E10 ~ OpSub ~ E10 ^^ ast_binary | E10 )
-    /** E10 = E11 OpMul E11 | E11 **/
-    lazy val E10: PackratParser[Expr] = E11 ~ OpMul ~ E11 ^^ ast_binary | E11 ~ OpDiv ~ E11 ^^ ast_binary  | E11 ~ OpUDiv ~ E11 ^^ ast_binary  | E11
+    lazy val E9: PackratParser[Expr] = positioned ( E9 ~ OpSub ~ E10 ^^ ast_binary | E10 )
+    /** E10 = E10 OpMul E11 | E10 OpDiv E11 | E10 OpUDiv E11 | E11 **/
+    lazy val E10: PackratParser[Expr] = E10 ~ OpMul ~ E11 ^^ ast_binary | E10 ~ OpDiv ~ E11 ^^ ast_binary  | E10 ~ OpUDiv ~ E11 ^^ ast_binary  | E11
     /** E11 = UnOp E12 | E12 **/
     lazy val E11: PackratParser[Expr] = positioned {
         OpNeg ~> E12 ^^ { case e => OperatorApplication(UnaryMinusOp(), List(e)) } |

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -210,7 +210,7 @@ class SMTLIB2Spec extends AnyFlatSpec {
     SMTLIB2Spec.expectedFails("./test/test-multiply-divide.ucl", 1)
   }
   "test-multiply-divide-subtract-chaining.ucl" should "verify all assertions." in {
-    SMTLIB2Spec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 0)
+    SMTLIB2Spec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 1)
   }
   "test-inliner.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-inliner.ucl", 0)

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -209,6 +209,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-multiply-divide.ucl" should "verify all but one assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-multiply-divide.ucl", 1)
   }
+  "test-multiply-divide-subtract-chaining.ucl" should "verify all assertions." in {
+    SMTLIB2Spec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 0)
+  }
   "test-inliner.ucl" should "verify successfully." in {
     SMTLIB2Spec.expectedFails("./test/test-inliner.ucl", 0)
   }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -212,6 +212,9 @@ class BasicVerifierSpec extends AnyFlatSpec {
   "test-multiply-divide.ucl" should "verify all but one assertions." in {
     VerifierSpec.expectedFails("./test/test-multiply-divide.ucl", 1)
   }
+  "test-multiply-divide-subtract-chaining.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 0)
+  }
   "test-smtlib-consts.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-smtlib-consts.ucl", 0)
   }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -213,7 +213,7 @@ class BasicVerifierSpec extends AnyFlatSpec {
     VerifierSpec.expectedFails("./test/test-multiply-divide.ucl", 1)
   }
   "test-multiply-divide-subtract-chaining.ucl" should "verify all assertions." in {
-    VerifierSpec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 0)
+    VerifierSpec.expectedFails("./test/test-multiply-divide-subtract-chaining.ucl", 1)
   }
   "test-smtlib-consts.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-smtlib-consts.ucl", 0)

--- a/test/test-multiply-divide-subtract-chaining.ucl
+++ b/test/test-multiply-divide-subtract-chaining.ucl
@@ -20,6 +20,7 @@ module main {
         assert(8 / 3 * 4 * 5 == 40);
         assert(2 * 3 / 4 * 5 == 5);
         assert(2 * 3 * 4 / 5 == 4);
+        assert(100 + 4 + 2 - 10 - 40 * 10 * 7 == -1104);
 	}
 
     control {

--- a/test/test-multiply-divide-subtract-chaining.ucl
+++ b/test/test-multiply-divide-subtract-chaining.ucl
@@ -1,0 +1,31 @@
+module main {
+	init {
+        // All assertions should pass
+
+        // Subtract with more than two operands
+        assert(100 - 20 - 10 == 70);
+        assert(400 - 100 - 200 - 50 - 50 == 0);
+
+        // Multiply with more than two operands
+        assert(10 * 5 * 2 == 100);
+        assert(2 * 3 * 4 * 10 * 5 == 1200);
+
+        // Divide with more than two operands
+        assert(100 / 3 / 2 == 16);
+        assert(100 / 6 / 3 / 2 == 2);
+
+        // Combine the operators
+        assert(100 + 4 + 2 - 10 - 40 * 10 * 3 == -1104);
+        assert(100 / 3 / 5 * 10 * 2 / 2 * 10 * 1 == 600);
+        assert(8 / 3 * 4 * 5 == 40);
+        assert(2 * 3 / 4 * 5 == 5);
+        assert(2 * 3 * 4 / 5 == 4);
+	}
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+        // print_module;
+    }
+}

--- a/tutorial/ch-grammar.tex
+++ b/tutorial/ch-grammar.tex
@@ -223,17 +223,17 @@ The usual logical and bitwise operators are allowed.
 As are relational operators, bitvector concatentation (++) and arithmetic.
 
 \begin{grammar}
-<E5> ::=  <E6> <RelOp> <E6> 
+<E5> ::=  <E6> <RelOp> <E6> | <E6>
 
 <RelOp> ::= `>' | `<' | `=' | `!=' | `>=' | `<='
 
-<E6> ::=  <E7> `++' <E6> 
+<E6> ::=  <E7> `++' <E6> | <E7>
 
-<E7> ::=  <E8> `+' <E7>
+<E7> ::=  <E8> `+' <E7> | <E8>
 
-<E8> ::=  <E9> `-' <E9>
+<E8> ::=  <E8> `-' <E9> | <E9>
 
-<E9> ::= <E10> `*' <E10>
+<E9> ::= <E9> `*' <E10> | <E9> `/' <E10> | <E10>
 \end{grammar}
 
 The unary operators are arithmetic negation (unary minus), logical negation and bitwise negation of bitvectors.


### PR DESCRIPTION
Subtractions, multiplications and divisions with more than two operands will now be parsed. For example, 2 * 3 * 4 which is evaluated as (((2*3)*4)*5).

Fixes #96