### PR TITLE
Add statement macros

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1473,7 +1473,8 @@ class SymbolicSimulator (module : Module) {
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |
                Scope.AxiomVar(_ , _, _)       | Scope.VerifResultVar(_, _)      |
-               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          =>
+               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          |
+               Scope.Macro(_, _, _)           =>
              throw new Utils.RuntimeError("Can't have this identifier in assertion: " + namedExpr.toString())
         }
       case None =>
@@ -1842,6 +1843,7 @@ class SymbolicSimulator (module : Module) {
       case CaseStmt(_) => throw new Utils.AssertionError("Cannot symbolically execute case statement.")
       case ProcedureCallStmt(id,lhss,args,instanceId,moduleId) => throw new Utils.AssertionError("Cannot symbolically execute procedure calls.")
       case ModuleCallStmt(_) => throw new Utils.AssertionError("Cannot symbolically execute module calls.")
+      case MacroCallStmt(_) => throw new Utils.AssertionError("Cannot symbolically execute macro calls.") 
     }
   }
 
@@ -1876,6 +1878,8 @@ class SymbolicSimulator (module : Module) {
     }
     case ModuleCallStmt(id) =>
       throw new Utils.RuntimeError("ModuleCallStmt must have been inlined by now.")
+    case MacroCallStmt(id) =>
+      throw new Utils.RuntimeError("MacroCallStmt must have been inlined by now")
   }
   def writeSets(stmts: List[Statement]) : Set[Identifier] = {
     return stmts.foldLeft(Set.empty[Identifier]){(acc,s) => acc ++ writeSet(s)}

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -224,6 +224,8 @@ object UclidMain {
     passManager.addPass(new RewritePolymorphicSelect())
     // Replaces constant lits with actual literal value
     passManager.addPass(new ConstantLitRewriter())
+    // inlines statement macros
+    passManager.addPass(new MacroRewriter())
     // finds uses of type defs
     passManager.addPass(new TypeSynonymFinder())
     // rewrites the type defs to be original type

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -1,0 +1,15 @@
+package uclid
+package lang
+
+class MacroRewriterPass extends RewritePass {
+  override def rewriteMacroCall(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
+    val mId = st.id
+    ctx.map.get(mId) match {
+      case Some(Scope.Macro(mId, typ, macroDecl)) => Some(macroDecl.body)
+      case _ => Some(st)
+    }
+  }
+}
+
+class MacroRewriter extends ASTRewriter(
+  "MacroRewriter", new MacroRewriterPass())

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -81,7 +81,8 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |
                Scope.AxiomVar(_ , _, _)       | Scope.VerifResultVar(_, _)      |
-               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          =>
+               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          |
+               Scope.Macro(_, _, _)           =>
              throw new Utils.ParserError("Can't have this identifier in define declaration: " + namedExpr.toString(), None, None)
         }
       case None =>

--- a/src/main/scala/uclid/lang/ModuleTypeChecker.scala
+++ b/src/main/scala/uclid/lang/ModuleTypeChecker.scala
@@ -231,6 +231,12 @@ class ModuleTypeCheckerPass extends ReadOnlyPass[Set[ModuleError]]
           } else {
             in
           }
+        case MacroCallStmt(id) =>
+          var ret = in
+          context.map.get(id) match {
+              case Some(Scope.Macro(mId, typ, macroDecl)) => ret
+              case _ => ret + ModuleError("Macro does not exist", id.position)
+          }
         case SkipStmt() => in
       }
     }

--- a/src/main/scala/uclid/lang/PrimedAssignmentChecker.scala
+++ b/src/main/scala/uclid/lang/PrimedAssignmentChecker.scala
@@ -100,7 +100,7 @@ class PrimedAssignmentCheckerPass extends ReadOnlyPass[Set[ModuleError]]
         }
       }
       st match {
-        case IfElseStmt(_, _, _)  | 
+        case IfElseStmt(_, _, _)  | MacroCallStmt(_)    |
              ForStmt(_, _, _, _)  | WhileStmt(_, _, _)  |
              CaseStmt(_)          | SkipStmt()          |
              AssertStmt(_, _)     | AssumeStmt(_, _)    |
@@ -121,6 +121,14 @@ class PrimedAssignmentCheckerPass extends ReadOnlyPass[Set[ModuleError]]
       in
     } else {
       checkLhs(callStmt.callLhss, in, context)
+    }
+  }
+
+  override def applyOnMacro(d : TraversalDirection.T, macroDecl : MacroDecl, in : T, context : Scope) : T = {
+    if (d == TraversalDirection.Up) {
+      Set.empty[ModuleError]
+    } else {
+      in
     }
   }
 }

--- a/src/main/scala/uclid/lang/Scope.scala
+++ b/src/main/scala/uclid/lang/Scope.scala
@@ -61,6 +61,7 @@ object Scope {
   case class SynthesisFunction(fId : Identifier, fTyp: FunctionSig, gId: Option[Identifier], gargs: List[Identifier], conds : List[Expr]) extends ReadOnlyNamedExpression(fId, fTyp.typ)
   case class OracleFunction(oId : Identifier, oTyp: FunctionSig, binary: String) extends ReadOnlyNamedExpression(oId, oTyp.typ)
   case class Define(dId : Identifier, dTyp : Type, defDecl: DefineDecl) extends ReadOnlyNamedExpression(dId, dTyp)
+  case class Macro(mId : Identifier, mTyp : Type, macroDecl: MacroDecl) extends ReadOnlyNamedExpression(mId, mTyp)
   case class Procedure(pId : Identifier, pTyp: Type) extends ReadOnlyNamedExpression(pId, pTyp)
   case class ProcedureInputArg(argId : Identifier, argTyp: Type) extends ReadOnlyNamedExpression(argId, argTyp)
   case class ProcedureOutputArg(argId : Identifier, argTyp: Type) extends NamedExpression(argId, argTyp)
@@ -265,6 +266,7 @@ case class Scope (
         case SynthesisFunctionDecl(id, sig, gid, gargs, conds) => Scope.addToMap(mapAcc, Scope.SynthesisFunction(id, sig, gid, gargs, conds))
         case OracleFunctionDecl(id, sig, binary) => Scope.addToMap(mapAcc, Scope.OracleFunction(id, sig, binary))
         case DefineDecl(id, sig, expr) => Scope.addToMap(mapAcc, Scope.Define(id, sig.typ, DefineDecl(id, sig, expr)))
+        case MacroDecl(id, sig, statement) => Scope.addToMap(mapAcc, Scope.Macro(id, sig.typ, MacroDecl(id, sig, statement)))
         case SpecDecl(id, expr, params) => Scope.addToMap(mapAcc, Scope.SpecVar(id, expr, params))
         case AxiomDecl(sId, expr, params) => sId match {
           case Some(id) => Scope.addToMap(mapAcc, Scope.AxiomVar(id, expr, params))
@@ -303,6 +305,10 @@ case class Scope (
           val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
           m2
         case DefineDecl(_, sig, _) =>
+          val m1 = sig.args.foldLeft(mapAcc)((mapAcc2, operand) => Scope.addTypeToMap(mapAcc2, operand._2, Some(m)))
+          val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
+          m2
+        case MacroDecl(_, sig, _) =>
           val m1 = sig.args.foldLeft(mapAcc)((mapAcc2, operand) => Scope.addTypeToMap(mapAcc2, operand._2, Some(m)))
           val m2 = Scope.addTypeToMap(m1, sig.retType, Some(m))
           m2

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -80,7 +80,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.ProcedureInputArg(_ , _) | Scope.ProcedureOutputArg(_ , _) |
                Scope.ForIndexVar(_ , _)       | Scope.SpecVar(_ , _, _)         |
                Scope.AxiomVar(_ , _, _)       | Scope.VerifResultVar(_, _)      |
-               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          =>
+               Scope.BlockVar(_, _)           | Scope.SelectorField(_)          |
+               Scope.Macro(_, _, _)           =>
              throw new Utils.RuntimeError("Can't have this identifier in assertion: " + namedExpr.toString())
         }
       case None =>
@@ -129,7 +130,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
                Scope.VerifResultVar(_, _)     | Scope.FunctionArg(_, _)         |
                Scope.Define(_, _, _)          | Scope.Grammar(_, _, _)          |
                Scope.ConstantLit(_, _)        | Scope.BlockVar(_, _)            |
-               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          =>
+               Scope.ForIndexVar(_ , _)       | Scope.SelectorField(_)          |
+               Scope.Macro(_, _, _)           =>
               id
           case Scope.ConstantVar(_, _)    | Scope.Function(_, _)  | Scope.OracleFunction(_,_,_) | Scope.SynthesisFunction(_, _, _, _, _) =>
              ExternalIdentifier(moduleName, id)

--- a/src/main/scala/uclid/lang/StatementScheduler.scala
+++ b/src/main/scala/uclid/lang/StatementScheduler.scala
@@ -102,6 +102,8 @@ object StatementScheduler {
         Utils.assert(namedExpr.isInstanceOf[Scope.Instance], "Must be a module instance: " + id.toString())
         val instD = namedExpr.asInstanceOf[Scope.Instance].instD
         instD.outputMap.map(p => p._3.asInstanceOf[Identifier]).toSet
+      case MacroCallStmt(_) =>
+        throw new Utils.AssertionError("Macro call statements must have been eliminated by now.")
     }
   }
   def writeSets(stmts: List[Statement], context : Scope) : (Set[Identifier]) = {
@@ -155,6 +157,8 @@ object StatementScheduler {
         Utils.assert(namedExpr.isInstanceOf[Scope.Instance], "Must be a module instance: " + id.toString())
         val instD = namedExpr.asInstanceOf[Scope.Instance].instD
         instD.outputMap.map(p => p._3.asInstanceOf[Identifier]).toSet
+      case MacroCallStmt(_) =>
+        throw new Utils.AssertionError("Macro call statements must have been eliminated by now.")
     }
   }
   def writeSetIds(stmts: List[Statement], context : Scope) : (Set[Identifier]) = {
@@ -224,6 +228,8 @@ object StatementScheduler {
         logger.trace("moduleInputs: {}", moduleInputs.toString())
         logger.trace("moduleSharedVars: {}", moduleSharedVars.toString())
         readSets(moduleInputs, prime) ++ readSets(moduleSharedVars, prime)
+      case MacroCallStmt(_) =>
+        throw new Utils.AssertionError("Macro call statements must have been eliminated by now.")
     }
   }
   def readSets(stmts : List[Statement], context : Scope, prime: Boolean = false) : (Set[Identifier]) = {

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1245,6 +1245,12 @@ case class DefineDecl(id: Identifier, sig: FunctionSig, expr: Expr) extends Decl
   override def toString = "define %s %s = %s;".format(id.toString, sig.toString, expr.toString)
   override def declNames = List(id)
 }
+case class MacroDecl(id: Identifier, sig: FunctionSig, body: Statement) extends Decl {
+  override def toString =
+    "macro // " + position.toString + "\n" +
+    Utils.join(body.toLines.map(PrettyPrinter.indent(2) + _), "\n")
+  override def declNames = List(id)
+}
 case class ModuleDefinesImportDecl(id: Identifier) extends Decl {
   override def toString = "define * = $s.*; // %s".format(id.toString)
   override def declNames = List.empty

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1012,6 +1012,11 @@ case class ProcedureCallStmt(id: Identifier, callLhss: List[Lhs], args: List[Exp
   override val hasCall = true
   override val hasInternalCall = instanceId.isEmpty
 }
+case class MacroCallStmt(id: Identifier) extends Statement {
+  override def toLines = List(id + "; // " + id.position.toString())
+  override val hasCall = false
+  override val hasInternalCall = false
+}
 case class ModuleCallStmt(id: Identifier) extends Statement {
   override def toLines = List("next (" + id.toString +")")
   override val hasCall = false
@@ -1247,7 +1252,7 @@ case class DefineDecl(id: Identifier, sig: FunctionSig, expr: Expr) extends Decl
 }
 case class MacroDecl(id: Identifier, sig: FunctionSig, body: Statement) extends Decl {
   override def toString =
-    "macro // " + position.toString + "\n" +
+    "macro " + id + "// " + position.toString + "\n" +
     Utils.join(body.toLines.map(PrettyPrinter.indent(2) + _), "\n")
   override def declNames = List(id)
 }

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -176,6 +176,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwHyperProperty = "hyperproperty"
     lazy val KwHyperInvariant = "hyperinvariant"
     lazy val KwHyperAxiom = "hyperaxiom"
+    lazy val KwMacro = "macro"
     // lazy val TemporalOpGlobally = "G"
     // lazy val TemporalOpFinally = "F"
     // lazy val TemporalOpNext = "Next"
@@ -199,7 +200,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       KwNext, KwLambda, KwModifies, KwProperty, KwDefineAxiom,
       KwForall, KwExists, KwDefault, KwSynthesis, KwGrammar, KwRequires,
       KwEnsures, KwInvariant, KwParameter, 
-      KwHyperProperty, KwHyperInvariant, KwHyperAxiom)
+      KwHyperProperty, KwHyperInvariant, KwHyperAxiom, KwMacro)
 
     lazy val ast_binary: Expr ~ String ~ Expr => Expr = {
       case x ~ OpBiImpl ~ y => OperatorApplication(IffOp(), List(x, y))
@@ -736,6 +737,10 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
         }
       }
     }
+    lazy val MacroDecl : PackratParser[lang.MacroDecl] = positioned {
+      KwMacro ~> Id ~ BlkStmt ^^
+        { case id ~ b => lang.MacroDecl(id, FunctionSig(List(), new UndefinedType()), b) }
+    }
     lazy val ModuleDefsImportDecl : PackratParser[lang.ModuleDefinesImportDecl] = positioned {
       KwDefine ~ "*" ~ "=" ~> Id <~ "." ~ "*" ~ ";" ^^ { case id => lang.ModuleDefinesImportDecl(id) }
     }
@@ -780,7 +785,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
                   VarsDecl | InputsDecl | OutputsDecl | SharedVarsDecl |
                   ConstLitDecl | ConstDecl | ProcedureDecl |
                   InitDecl | NextDecl | SpecDecl | AxiomDecl |
-                  ModuleImportDecl)
+                  ModuleImportDecl | MacroDecl)
 
     // control commands.
     lazy val CmdParam : PackratParser[lang.CommandParams] = 

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -478,6 +478,8 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
         { case instanceId ~ "." ~ procId ~ args => ProcedureCallStmt(procId, List.empty, args, Some(instanceId)) } |
       KwCall ~> LhsList ~ ("=" ~> Id) ~ "." ~ Id ~ ExprList <~ ";" ^^
         { case lhss ~ instanceId ~ "." ~ procId ~ args => ProcedureCallStmt(procId, lhss, args, Some(instanceId)) } |
+      Id <~ ";" ^^
+        { case macroId => lang.MacroCallStmt(macroId) } |
       KwNext ~ "(" ~> Id <~ ")" ~ ";" ^^
         { case id => lang.ModuleCallStmt(id) } |
       KwIf ~ "(" ~ "*" ~ ")" ~> (BlkStmt <~ KwElse) ~ BlkStmt ^^

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -806,7 +806,8 @@ class ParserSpec extends AnyFlatSpec {
       val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-macro-parse-fails.ucl"), lang.Identifier("main"))
       assert (false)
     } catch {
-      case e : Utils.ParserError  => assert(e.msg.contains("Macro does not exist"))
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.exists(p => p._1.contains("Macro does not exist")))
     }
   }
 

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -801,5 +801,13 @@ class ParserSpec extends AnyFlatSpec {
       case _: Throwable => assert (false)
     }
   }
+  "test-macro-parse-fails.ucl" should "not parse successfully" in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-macro-parse-fails.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case e : Utils.ParserError  => assert(e.msg.contains("Macro does not exist"))
+    }
+  }
 
 }

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -521,4 +521,16 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-too-many-vars-error.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-too-many-vars-error.ucl", 0)
   }
+  "test-macro-1.ucl" should "fail to verify 1 assertion." in {
+    SMTLIB2Spec.expectedFails("./test/test-macro-1.ucl", 1)
+  }
+  "test-macro-2.ucl" should "verify all assertions." in {
+    SMTLIB2Spec.expectedFails("./test/test-macro-2.ucl", 0)
+  }
+  "test-macro-3.ucl" should "verify all assertions." in {
+    SMTLIB2Spec.expectedFails("./test/test-macro-3.ucl", 0)
+  }
+  "test-macro-4.ucl" should "fail to verify 1 assertion." in {
+    SMTLIB2Spec.expectedFails("./test/test-macro-4.ucl", 1)
+  }
 }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -462,6 +462,18 @@ class ModuleVerifSpec extends AnyFlatSpec {
   "test-redundant-assign.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-redundant-assign.ucl", 0)
   }
+  "test-macro-1.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-macro-1.ucl", 1)
+  }
+  "test-macro-2.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-macro-2.ucl", 0)
+  }
+  "test-macro-3.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-macro-3.ucl", 0)
+  }
+  "test-macro-4.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-macro-4.ucl", 1)
+  }
 }
 class LTLVerifSpec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {

--- a/test/test-macro-1.ucl
+++ b/test/test-macro-1.ucl
@@ -12,7 +12,14 @@ module main {
     }
 
     init {
-        x = 0;
+        x = 2;
+        y = 2;
+        assert(x == 0);
+        one;
+        assert(x == 0);
+        two;
+        assert(x == 1);
+        assert(y == 1);
     }
     
     control {

--- a/test/test-macro-2.ucl
+++ b/test/test-macro-2.ucl
@@ -1,0 +1,23 @@
+module main {
+    var a, b : integer;
+
+    init {
+        fib_init;
+    }
+    next {
+        a', b' = b, a + b;
+    }
+
+    macro fib_init {
+        a = 0;
+        b = 1;
+    }
+
+    invariant a_le_b: a <= b;
+  
+    control {
+      unroll (3);
+      check;
+      print_results;
+    }
+}

--- a/test/test-macro-3.ucl
+++ b/test/test-macro-3.ucl
@@ -1,0 +1,38 @@
+module main {
+  // System description. 
+  var a, b   : integer;
+  const flag : boolean;
+
+  macro embedded_assumptions {
+    assume (a <= b);
+    assume (a >= 0 && b >= 0);
+    assume (flag);
+  }
+
+  procedure set_init()
+    modifies a, b;
+  {
+    havoc a;
+    havoc b;
+    embedded_assumptions;
+  }
+
+  init {
+    call set_init();
+  }
+  next {
+    a', b' = b, a + b;
+    if (flag) {
+      assert (a' <= b');
+    } else {
+      assert (false);
+    }
+  }
+
+  // Proof script.
+  control {
+    unroll (3);
+    check;
+    print_results;
+  }
+}

--- a/test/test-macro-4.ucl
+++ b/test/test-macro-4.ucl
@@ -1,0 +1,22 @@
+module main {
+    macro assertions {
+        assert(x == 2);
+        assert(y == 3);
+        assert(x == y);
+    }
+
+    var x : integer;
+    var y : integer;
+
+    init {
+        x = 2;
+        y = 3;
+        assertions;
+    }
+    
+    control {
+        unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-macro-parse-fails.ucl
+++ b/test/test-macro-parse-fails.ucl
@@ -1,0 +1,20 @@
+module main {
+    var x : integer;
+    var y : integer;
+
+    macro foo {
+        x = 0;
+    }
+
+    init {
+        y = 2;
+        foo;
+        bar;
+    }
+    
+    control {
+        unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-macro.ucl
+++ b/test/test-macro.ucl
@@ -1,0 +1,23 @@
+module main {
+    var x : integer;
+    var y : integer;
+
+    macro one {
+        x = 0;
+    }
+
+    macro two {
+        x = 1;
+        y = 1;
+    }
+
+    init {
+        x = 0;
+    }
+    
+    control {
+        unroll(0);
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
Adds statement macros (currently non-parameterised) which can be applied in procedural environements. An example of the syntax of a macro declaration is the following:
```
macro foo {
    x = 1;
    y = 2;
}
```