### PR TITLE
remove test from uclidMain

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -92,7 +92,7 @@ object UclidMain {
 
       opt[String]('s', "solver").valueName("<Cmd>").action{ 
         (exec, c) => c.copy(smtSolver = exec.split(" ").toList) 
-      }.text("External SMT solver binary.")
+      }.text("Command line to invoke external SMT solver binary.")
 
       opt[String]('y', "synthesizer").valueName("<Cmd>").action{
         (exec, c) => c.copy(synthesizer = exec.split(" ").toList)

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -126,10 +126,6 @@ object UclidMain {
         (_, c) => c.copy(ufToArray = true)
       }.text("Enable conversion from Uninterpreted Functions to Arrays.")
 
-      opt[Unit]('t', "test-fixedpoint").action {
-        (_, c) => c.copy(testFixedpoint = true)
-      }.text("Test fixed point")
-
       help("help").text("prints this usage text")
 
       arg[java.io.File]("<file> ...").unbounded().required().action {
@@ -145,10 +141,6 @@ object UclidMain {
    */
   def main(config : Config) {
     try {
-      if (config.testFixedpoint) {
-        smt.Z3HornSolver.test1()
-        return
-      }
       val mainModuleName = Identifier(config.mainModuleName)
       val modules = compile(config, mainModuleName)
       val mainModule = instantiate(config, modules, mainModuleName, true)


### PR DESCRIPTION
There was a legacy command line option to run a simple test in the Z3 Horn Solver. It's not the right place to run tests, and it doesn't test very much, so I'm removing it. 