### PR TITLE
renaming variables in define

### DIFF
--- a/src/main/scala/uclid/lang/BlockFlattener.scala
+++ b/src/main/scala/uclid/lang/BlockFlattener.scala
@@ -92,6 +92,18 @@ class BlockVariableRenamerPass extends RewritePass {
     val funcP = FunctionDecl(func.id, sigP)
     Some(funcP)
   }
+
+  override def rewriteDefine(defDecl : DefineDecl, context : Scope) : Option[DefineDecl] = {
+    val varTuples = renameVarList(defDecl.sig.args, context)
+    val contextP = context + defDecl.sig
+    val rewriteMap = getRewriteMap(varTuples)
+    val rewriter = new ExprRewriter("BlockVariableRenamerPass:Define", rewriteMap)
+    val argsP = defDecl.sig.args.map(arg => (rewriter.rewriteExpr(arg._1, contextP).asInstanceOf[Identifier], arg._2))
+    val sigP = FunctionSig(argsP, defDecl.sig.retType)
+    val bodyP = rewriter.rewriteExpr(defDecl.expr, contextP)
+    val defP = DefineDecl(defDecl.id, sigP, bodyP) 
+    Some(defP)
+  }
 }
 
 object BlockVariableRenamer {

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -420,6 +420,9 @@ class ModuleVerifSpec extends AnyFlatSpec {
   "test-def-import-4.ucl" should "verify 2 assertions, fail 1." in {
     VerifierSpec.expectedFails("./test/test-def-import-4.ucl", 1)
   }
+  "test-renaming-defines.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-renaming-defines.ucl", 0)
+  }
   "test-procedure-postcondition-1.ucl" should "verify all but one assertion." in {
     VerifierSpec.expectedFails("./test/test-procedure-postcondition-1.ucl", 1)
   }

--- a/test/test-renaming-defines.ucl
+++ b/test/test-renaming-defines.ucl
@@ -1,0 +1,21 @@
+module main {
+    var aliased : [integer][integer]boolean;
+    define Aliased (i, j : integer) : boolean = (aliased[i][j]);
+    axiom aliased[0][1];
+
+    var j : integer;
+    var i : integer;
+
+    property test: Aliased(j,i);
+    init {
+        j=0;
+        i=1;
+    }
+    next {
+    }
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
This fixes the issue @lsk567 and @ymanerka reported where variable names in defines were getting mixed up