### PR TITLE
Add command to modify statement macro from control block

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -326,6 +326,10 @@ class SymbolicSimulator (module : Module) {
                 "Unexpected option value: " + cmd.args(1)._1.toString)
             }
             solver.addOption(option, value)
+          case "assign_macro" =>
+            UclidMain.println("This will modify a macro")
+            UclidMain.println(cmd.args(0).toString())
+            UclidMain.println(cmd.macroBody.toString())
           case _ =>
             throw new Utils.UnimplementedException("Command not supported: " + cmd.toString)
         }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -153,7 +153,23 @@ object UclidMain {
       val modules = compile(config, mainModuleName)
       val mainModule = instantiate(config, modules, mainModuleName, true)
       mainModule match {
-        case Some(m) => execute(m, config)
+        case Some(m) =>
+          var cmdBlocks = List(List(m.cmds(0)))
+          for (cmd <- m.cmds.tail)
+            if (cmd.modifiesModule)
+              cmdBlocks = cmdBlocks :+ List(cmd)
+            else
+              cmdBlocks = cmdBlocks.init :+ (cmdBlocks.last :+ cmd)
+          for (cmdBlock <- cmdBlocks) {
+            if (cmdBlock(0).modifiesModule) {
+              val newMacroBody = cmdBlock(0).macroBody match {
+                case Some(mb) => mb
+                case _ => throw new Utils.RuntimeError("assign_macro command should include a new macro body")
+              }
+            }
+            m.cmds = cmdBlock
+            execute(m, config)
+          }
         case None    =>
           throw new Utils.ParserError("Unable to find main module", None, None)
       }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -154,21 +154,16 @@ object UclidMain {
       val mainModule = instantiate(config, modules, mainModuleName, true)
       mainModule match {
         case Some(m) =>
+          // Split the control block commands to blocks on commands that modify themodule
           var cmdBlocks = List(List(m.cmds(0)))
           for (cmd <- m.cmds.tail)
             if (cmd.modifiesModule)
               cmdBlocks = cmdBlocks :+ List(cmd)
             else
               cmdBlocks = cmdBlocks.init :+ (cmdBlocks.last :+ cmd)
+          // Execute the commands for each block
           for (cmdBlock <- cmdBlocks) {
-            if (cmdBlock(0).modifiesModule) {
-              val newMacroBody = cmdBlock(0).macroBody match {
-                case Some(mb) => mb
-                case _ => throw new Utils.RuntimeError("assign_macro command should include a new macro body")
-              }
-            }
-            m.cmds = cmdBlock
-            execute(m, config)
+            executeCommands(m, cmdBlock, config)
           }
         case None    =>
           throw new Utils.ParserError("Unable to find main module", None, None)
@@ -424,6 +419,31 @@ object UclidMain {
     val result = symbolicSimulator.execute(solverInterface, config)
     solverInterface.finish()
     return result
+  }
+
+  def executeCommands(module : Module, cmds : List[GenericProofCommand], config : Config) : List[CheckResult] = {
+    var resModule = module
+    if (cmds(0).name == Identifier("assign_macro")) {
+      val newMacroBody = cmds(0).macroBody match {
+        case Some(b) => b
+        case _ => throw new Utils.RuntimeError("assign_macro command should include a new macro body")
+      }
+      val macroId = cmds(0).args(0)._1 match {
+        case Identifier(n) => Identifier(n)
+        case _ => throw new Utils.RuntimeError("assign_macro argument should be a macro identifier")
+      }
+      resModule = assignMacro(module, macroId, newMacroBody)
+      resModule.cmds = cmds.tail
+    } else {
+      resModule.cmds = cmds
+    }
+    return execute(resModule, config)
+  }
+
+  def assignMacro(module : Module, macroId : Identifier, newMacroBody : BlockStmt) : Module = {
+    val passManager = new PassManager("assign_macro")
+    passManager.addPass(new MacroReplacer(macroId, newMacroBody))
+    passManager.run(List(module))(0)
   }
 
   var stringOutput : StringBuilder = new StringBuilder()

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -426,7 +426,6 @@ object UclidMain {
         cmdBlocks = cmdBlocks.init :+ (cmdBlocks.last :+ cmd)
       previousModifiesModule = cmd.modifiesModule
     })
-    UclidMain.println(cmdBlocks.toString)
     return cmdBlocks
   }
 
@@ -448,7 +447,7 @@ object UclidMain {
             case Identifier(n) => Identifier(n)
             case _ => throw new Utils.RuntimeError("Should never get here")
           }
-          resModule = assignMacro(module, macroId, newMacroBody)
+          resModule = assignMacro(resModule, macroId, newMacroBody)
           modifyCmdCount += 1
         case _ =>
           if (previousModifiesModule) {

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -231,6 +231,7 @@ object UclidMain {
     // checks for invalid statements in macros and incorrect usage
     passManager.addPass(new MacroChecker())
     // inlines statement macros
+    passManager.addPass(new MacroAnnotator())
     passManager.addPass(new MacroRewriter())
     // finds uses of type defs
     passManager.addPass(new TypeSynonymFinder())

--- a/src/main/scala/uclid/lang/ASTVistors.scala
+++ b/src/main/scala/uclid/lang/ASTVistors.scala
@@ -1341,11 +1341,16 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
     val idP = visitIdentifier(macroDecl.id, context)
     val sigP = visitFunctionSig(macroDecl.sig, context)
     val contextP = context + macroDecl.sig
-    val statementP = visitStatement(macroDecl.body, contextP)
+    val statementP = visitBlockStatement(macroDecl.body, contextP)
     (idP, sigP, statementP) match {
       case (Some(id), Some(sig), Some(statement)) =>
-        val macroDeclP = MacroDecl(id, sig, statement)
-        pass.rewriteMacro(macroDeclP, context)
+        if(statement.isInstanceOf[BlockStmt])
+        {
+          val macroDeclP = MacroDecl(id, sig, statement.asInstanceOf[BlockStmt])
+          pass.rewriteMacro(macroDeclP, context)
+        }
+        else
+          None
       case _ =>
         None
     }

--- a/src/main/scala/uclid/lang/ASTVistors.scala
+++ b/src/main/scala/uclid/lang/ASTVistors.scala
@@ -1491,7 +1491,7 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
     }).flatten
     val resultVarP = cmd.resultVar.flatMap(r => visitIdentifier(r, contextP))
     val argObjP = cmd.argObj.flatMap(r => visitIdentifier(r, contextP))
-    val cmdP = pass.rewriteCommand(GenericProofCommand(cmd.name, cmd.params, argsP, resultVarP, argObjP), context)
+    val cmdP = pass.rewriteCommand(GenericProofCommand(cmd.name, cmd.params, argsP, resultVarP, argObjP, cmd.macroBody), context)
     return ASTNode.introducePos(setPosition, setFilename, cmdP, cmd.position)
   }
 

--- a/src/main/scala/uclid/lang/ControlCommandChecker.scala
+++ b/src/main/scala/uclid/lang/ControlCommandChecker.scala
@@ -211,6 +211,10 @@ class ControlCommandCheckerPass extends ReadOnlyPass[Unit] {
         checkNoParams(cmd, filename)
         checkHasArgObj(cmd, filename, context)
         checkNoResultVar(cmd, filename)
+      case "assign_macro" =>
+        checkNoParams(cmd, filename)
+        checkNoArgObj(cmd, filename)
+        checkNoResultVar(cmd, filename)
       case _ =>
         Utils.raiseParsingError("Unknown control command: " + cmd.name.toString, cmd.pos, filename)
     }

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -27,7 +27,7 @@ class MacroReplacerPass extends RewritePass {
       {
         var body  = macroDecl.body
         body.macroAnnotation = Some(MacroAnnotation(mId,macroDecl.body.stmts.size))
-        Some(macroDecl.body)
+        Some(body)
       }
       case _ => Some(st)
     }

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -1,11 +1,55 @@
 package uclid
 package lang
 
-class MacroRewriterPass extends RewritePass {
+
+class MacroReplacerPass extends RewritePass {
+
+
+  override def rewriteBlock(st: BlockStmt, ctx: Scope): Option[Statement] = {
+    // if all statements in block have macro annotation, replace all statements with macro 
+    // (add macro annotation to new block)
+    // throw runtime error if macro doesn't exist
+
+    // if some statements but not all have macro annotations, throw error? we replace full blocks only?
+
+    // if no statements have macro annotations, return original block
+    Some(st)
+  }
+
+  override def rewriteStatement(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
+  }
+
+
+// should not be any macro call statements?
   override def rewriteMacroCall(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
     val mId = st.id
     ctx.map.get(mId) match {
-      case Some(Scope.Macro(mId, typ, macroDecl)) => Some(macroDecl.body)
+      case Some(Scope.Macro(mId, typ, macroDecl)) => 
+      {
+        var body  = macroDecl.body
+        body.macroAnnotation = Some(MacroAnnotation(mId,macroDecl.body.stmts.size))
+        Some(macroDecl.body)
+      }
+      case _ => Some(st)
+    }
+  }
+}
+
+class MacroReplacer extends ASTRewriter(
+  "MacroReplacer", new MacroRewriterPass())
+
+
+class MacroRewriterPass extends RewritePass {
+
+  override def rewriteMacroCall(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
+    val mId = st.id
+    ctx.map.get(mId) match {
+      case Some(Scope.Macro(mId, typ, macroDecl)) => 
+      {
+        var body  = macroDecl.body
+        body.macroAnnotation = Some(MacroAnnotation(mId,macroDecl.body.stmts.size))
+        Some(macroDecl.body)
+      }
       case _ => Some(st)
     }
   }

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -15,40 +15,42 @@ class MacroReplacerPass extends RewritePass {
     // if no statements have macro annotations, return original block
     Some(st)
   }
-
-
-
-
-// should not be any macro call statements?
-  override def rewriteMacroCall(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
-    val mId = st.id
-    ctx.map.get(mId) match {
-      case Some(Scope.Macro(mId, typ, macroDecl)) => 
-      {
-        var body  = macroDecl.body
-        body.macroAnnotation = Some(MacroAnnotation(mId,macroDecl.body.stmts.size))
-        Some(body)
-      }
-      case _ => Some(st)
-    }
-  }
 }
 
 class MacroReplacer extends ASTRewriter(
   "MacroReplacer", new MacroRewriterPass())
 
+class MacroAnnotationCollector extends ReadOnlyPass [MacroAnnotation] {
+  type T = MacroAnnotation
+
+  override def applyOnMacro(d : TraversalDirection.T, macroDecl : MacroDecl, in : T, context : Scope) : T = {
+    val listOfPositions = macroDecl.body.stmts.foldLeft(List[ASTPosition]()){
+      (acc, s)  => acc :+ s.position }
+      val newMap = in.macroMap + (macroDecl.id -> listOfPositions)
+      MacroAnnotation(newMap)
+  }
+}
+
+class MacroAnnotator extends ASTAnalyzer(
+  "MacroAnnotator", new MacroAnnotationCollector())
+{
+  override def reset() {
+    in = Some(MacroAnnotation(Map[Identifier, List[ASTPosition]]()))
+  }
+
+  override def visit(module : Module, context : Scope) : Option[Module] = {
+    val macroAnnotationMap = visitModule(module, MacroAnnotation(Map[Identifier, List[ASTPosition]]()), context)
+    _out = Some(macroAnnotationMap)
+    return Some(Module(module.id, module.decls, module.cmds, module.notes :+ macroAnnotationMap))
+  }
+}
 
 class MacroRewriterPass extends RewritePass {
 
   override def rewriteMacroCall(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
     val mId = st.id
     ctx.map.get(mId) match {
-      case Some(Scope.Macro(mId, typ, macroDecl)) => 
-      {
-        var body  = macroDecl.body
-        body.macroAnnotation = Some(MacroAnnotation(mId,macroDecl.body.stmts.size))
-        Some(macroDecl.body)
-      }
+      case Some(Scope.Macro(mId, typ, macroDecl)) => Some(macroDecl.body)
       case _ => Some(st)
     }
   }

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -16,8 +16,7 @@ class MacroReplacerPass extends RewritePass {
     Some(st)
   }
 
-  override def rewriteStatement(st: MacroCallStmt, ctx: Scope): Option[Statement] = {
-  }
+
 
 
 // should not be any macro call statements?

--- a/src/main/scala/uclid/lang/MacroRewriter.scala
+++ b/src/main/scala/uclid/lang/MacroRewriter.scala
@@ -26,7 +26,6 @@ class MacroReplacerPass(macroId : Identifier, newMacroBody : BlockStmt) extends 
           // These statements are expected to be contiguous
           Some(replaceMacroWithinBlock(st, macroPositions, newMacroBody))
         }
-        Some(st)
       case _ => 
         Some(st)
     }
@@ -39,6 +38,7 @@ class MacroReplacerPass(macroId : Identifier, newMacroBody : BlockStmt) extends 
     var (leftStmts, rightStmts) = st.stmts.span(s => !(macroPositions contains s.position))
     while (!rightStmts.isEmpty) {
       leftStmts = leftStmts ++ newMacroBody.stmts
+      rightStmts = rightStmts.dropWhile(s => macroPositions contains s.position)
       rightStmts.span(s => !(macroPositions contains s.position)) match {
         case (l, r) =>
           leftStmts = leftStmts ++ l
@@ -46,7 +46,7 @@ class MacroReplacerPass(macroId : Identifier, newMacroBody : BlockStmt) extends 
         case _ =>
       }
     }
-    leftStmts
+    BlockStmt(st.vars, leftStmts)
   }
 }
 

--- a/src/main/scala/uclid/lang/ModularProductProgram.scala
+++ b/src/main/scala/uclid/lang/ModularProductProgram.scala
@@ -1267,7 +1267,7 @@ class ModularProductProgramPass extends RewritePass {
                                 val newArgs = ListBuffer[(Expr, String)]()
                                 val tup = (modularProcedure.id.asInstanceOf[Expr], modularProcedure.id.name)
                                 newArgs += tup
-                                val newCommand = GenericProofCommand(command.name, command.params, newArgs.toList, newResultVar, command.argObj)
+                                val newCommand = GenericProofCommand(command.name, command.params, newArgs.toList, newResultVar, command.argObj, command.macroBody)
                                 ASTNode.introducePos(true, true, newCommand, command.position)
                                 newCommands  += newCommand
 
@@ -1296,7 +1296,7 @@ class ModularProductProgramPass extends RewritePass {
                                                     newArgs += newtuple
                                                 }
                                             }
-                                            val newCommand = GenericProofCommand(command.name, command.params, newArgs.toList, command.resultVar, newArgObj)
+                                            val newCommand = GenericProofCommand(command.name, command.params, newArgs.toList, command.resultVar, newArgObj, command.macroBody)
                                             ASTNode.introducePos(true, true, newCommand, command.position)
                                             newCommands += newCommand
                                         }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1395,7 +1395,7 @@ case class CommandParams(name: Identifier, values: List[Expr]) extends ASTNode
 
 case class GenericProofCommand(
     name : Identifier, params: List[CommandParams], args : List[(Expr, String)], 
-    resultVar: Option[Identifier], argObj: Option[Identifier]) 
+    resultVar: Option[Identifier], argObj: Option[Identifier], macroBody: Option[BlockStmt]) 
   extends ProofCommand {
 
   def getContext(context : Scope) : Scope = {
@@ -1429,6 +1429,8 @@ case class GenericProofCommand(
     resultStr + objStr + nameStr + paramStr + argStr + ";" + " // " + position.toString
   }
   def isPrintCEX : Boolean = { name == Identifier("print_cex") }
+
+  def modifiesModule : Boolean = { name == Identifier("assign_macro") }
 }
 
 sealed abstract class Annotation extends ASTNode
@@ -1475,7 +1477,7 @@ object Annotation {
   val default = List(InstanceVarMapAnnotation(Map.empty))
 }
 
-case class Module(id: Identifier, decls: List[Decl], cmds : List[GenericProofCommand], notes: List[Annotation]) extends ASTNode {
+case class Module(id: Identifier, decls: List[Decl], var cmds : List[GenericProofCommand], notes: List[Annotation]) extends ASTNode {
   // create a new module with with the filename set.
   def withFilename(name : String) : Module = {
     val newModule = Module(id, decls, cmds, notes)

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -915,7 +915,7 @@ sealed abstract class Statement extends ASTNode {
   override def toString = 
   {
     if(macroAnnotation.isEmpty)
-      Utils.join(toLines, "\n") + "\n"
+      Utils.join(toLines, "\n") + "no macro annotation \n"
     else
       Utils.join(toLines, "\\ was macro " + macroAnnotation.toString + "\n ") + "\n"
   }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -914,10 +914,7 @@ sealed abstract class Statement extends ASTNode {
 
   override def toString = 
   {
-    if(macroAnnotation.isEmpty)
-      Utils.join(toLines, "\n") + "no macro annotation \n"
-    else
-      Utils.join(toLines, "\\ was macro " + macroAnnotation.toString + "\n ") + "\n"
+      Utils.join(toLines, "\n")
   }
   // TODO: these should be moved to annotations?
   def hasStmtBlock = false
@@ -925,7 +922,6 @@ sealed abstract class Statement extends ASTNode {
   val hasLoop = false
   val hasCall : Boolean
   val hasInternalCall : Boolean
-  var macroAnnotation: Option[MacroAnnotation] = None;
   def toLines : List[String]
 }
 case class SkipStmt() extends Statement {
@@ -1266,10 +1262,6 @@ case class MacroDecl(id: Identifier, sig: FunctionSig, body: BlockStmt) extends 
   override def declNames = List(id)
 }
 
-case class MacroAnnotation(id: Identifier, size: Int) extends Annotation {
-  override def toString = id.toString;
-}
-
 case class ModuleDefinesImportDecl(id: Identifier) extends Decl {
   override def toString = "define * = $s.*; // %s".format(id.toString)
   override def declNames = List.empty
@@ -1452,6 +1444,15 @@ case class InstanceVarMapAnnotation(iMap: Map[List[Identifier], Identifier]) ext
     val start = PrettyPrinter.indent(1) + "// instance_var_map { "
     val lines = iMap.map(p => PrettyPrinter.indent(1) + "//   " + Utils.join(p._1.map(_.toString), ".") + " ::==> " + p._2.toString)
     val end = PrettyPrinter.indent(1) + "// } end_instance_var_map"
+    Utils.join(List(start) ++ lines ++ List(end), "\n") +"\n"
+  }
+}
+
+case class MacroAnnotation(macroMap: Map[Identifier, List[ASTPosition]]) extends Annotation{
+  override def toString : String = {
+    val start = PrettyPrinter.indent(1) + "// macro_annotation_map { "
+    val lines = macroMap.map(p => PrettyPrinter.indent(1) + "//   " + Utils.join(p._2.map(_.toString), " + ") + " ::==> " + p._1.toString)
+    val end = PrettyPrinter.indent(1) + "// } end_macro_annotation_map"
     Utils.join(List(start) ++ lines ++ List(end), "\n") +"\n"
   }
 }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1451,7 +1451,7 @@ case class InstanceVarMapAnnotation(iMap: Map[List[Identifier], Identifier]) ext
 case class MacroAnnotation(macroMap: Map[Identifier, List[ASTPosition]]) extends Annotation{
   override def toString : String = {
     val start = PrettyPrinter.indent(1) + "// macro_annotation_map { "
-    val lines = macroMap.map(p => PrettyPrinter.indent(1) + "//   " + Utils.join(p._2.map(_.toString), " + ") + " ::==> " + p._1.toString)
+    val lines = macroMap.map(p => PrettyPrinter.indent(1) + "//   " + p._1.toString + " ::===>" + Utils.join(p._2.map(_.toString), " + ") )
     val end = PrettyPrinter.indent(1) + "// } end_macro_annotation_map"
     Utils.join(List(start) ++ lines ++ List(end), "\n") +"\n"
   }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -911,12 +911,21 @@ case class HavocableInstanceId(opapp : OperatorApplication) extends HavocableEnt
 
 /** Statements **/
 sealed abstract class Statement extends ASTNode {
-  override def toString = Utils.join(toLines, "\n") + "\n"
+
+  override def toString = 
+  {
+    if(macroAnnotation.isEmpty)
+      Utils.join(toLines, "\n") + "\n"
+    else
+      Utils.join(toLines, "\\ was macro " + macroAnnotation.toString + "\n ") + "\n"
+  }
+  // TODO: these should be moved to annotations?
   def hasStmtBlock = false
   val isLoop = false
   val hasLoop = false
   val hasCall : Boolean
   val hasInternalCall : Boolean
+  var macroAnnotation: Option[MacroAnnotation] = None;
   def toLines : List[String]
 }
 case class SkipStmt() extends Statement {
@@ -949,10 +958,10 @@ case class BlockStmt(vars: List[BlockVarsDecl], stmts: List[Statement]) extends 
   override def hasStmtBlock = true
   override val hasLoop = stmts.exists(st => st.hasLoop)
   override def toLines = { 
-    List("{") ++
+      List("{ //" ) ++
       vars.map(PrettyPrinter.indent(1) + _.toString()) ++
       stmts.flatMap(_.toLines).map(PrettyPrinter.indent(1) + _) ++
-    List("}")
+      List("}")
   }
   override val hasCall = stmts.exists(st => st.hasCall)
   override val hasInternalCall = stmts.exists(st => st.hasInternalCall)
@@ -1250,12 +1259,17 @@ case class DefineDecl(id: Identifier, sig: FunctionSig, expr: Expr) extends Decl
   override def toString = "define %s %s = %s;".format(id.toString, sig.toString, expr.toString)
   override def declNames = List(id)
 }
-case class MacroDecl(id: Identifier, sig: FunctionSig, body: Statement) extends Decl {
+case class MacroDecl(id: Identifier, sig: FunctionSig, body: BlockStmt) extends Decl {
   override def toString =
     "macro " + id + "// " + position.toString + "\n" +
     Utils.join(body.toLines.map(PrettyPrinter.indent(2) + _), "\n")
   override def declNames = List(id)
 }
+
+case class MacroAnnotation(id: Identifier, size: Int) extends Annotation {
+  override def toString = id.toString;
+}
+
 case class ModuleDefinesImportDecl(id: Identifier) extends Decl {
   override def toString = "define * = $s.*; // %s".format(id.toString)
   override def declNames = List.empty
@@ -1438,15 +1452,6 @@ case class InstanceVarMapAnnotation(iMap: Map[List[Identifier], Identifier]) ext
     val start = PrettyPrinter.indent(1) + "// instance_var_map { "
     val lines = iMap.map(p => PrettyPrinter.indent(1) + "//   " + Utils.join(p._1.map(_.toString), ".") + " ::==> " + p._2.toString)
     val end = PrettyPrinter.indent(1) + "// } end_instance_var_map"
-    Utils.join(List(start) ++ lines ++ List(end), "\n") +"\n"
-  }
-}
-
-case class InstanceProcMapAnnotation(iMap: Map[List[Identifier], ProcedureDecl]) extends Annotation {
-  override def toString : String = {
-    val start = PrettyPrinter.indent(1) + "// instance_proc_map { "
-    val lines = iMap.map(p => PrettyPrinter.indent(1) + "//   " + Utils.join(p._1.map(_.toString), ".") + " ::==> " + p._2.toString)
-    val end = PrettyPrinter.indent(1) + "// } end_instance_proc_map"
     Utils.join(List(start) ++ lines ++ List(end), "\n") +"\n"
   }
 }

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -803,13 +803,15 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
 
     lazy val Cmd : PackratParser[lang.GenericProofCommand] = positioned {
       (Id <~ "=").? ~ (Id <~ ".").? ~ Id <~ ";" ^^
-        { case rId ~ oId ~ id => lang.GenericProofCommand(id, List.empty, List.empty, rId, oId) } |
+        { case rId ~ oId ~ id => lang.GenericProofCommand(id, List.empty, List.empty, rId, oId, None) } |
       (Id <~ "=").? ~ (Id <~ ".").? ~ Id ~ CmdParamList <~ ";" ^^
-        { case rId ~ oId ~ id ~ cmdParams => lang.GenericProofCommand(id, cmdParams, List.empty, rId, oId) } |
+        { case rId ~ oId ~ id ~ cmdParams => lang.GenericProofCommand(id, cmdParams, List.empty, rId, oId, None) } |
       (Id <~ "=").? ~ (Id <~ ".").? ~ Id ~ ExprList <~ ";" ^^
-        { case rId ~ oId ~ id ~ es => lang.GenericProofCommand(id, List.empty, es.map(e => (e, e.toString())), rId, oId) } |
+        { case rId ~ oId ~ id ~ es => lang.GenericProofCommand(id, List.empty, es.map(e => (e, e.toString())), rId, oId, None) } |
       (Id <~ "=").? ~ (Id <~ ".").? ~ Id ~ CmdParamList ~ ExprList <~ ";" ^^
-        { case rId ~ oId ~ id ~ cmdParams ~ es => lang.GenericProofCommand(id, cmdParams, es.map(e => (e, e.toString())), rId, oId) }
+        { case rId ~ oId ~ id ~ cmdParams ~ es => lang.GenericProofCommand(id, cmdParams, es.map(e => (e, e.toString())), rId, oId, None) } |
+      (Id <~ "=").? ~ (Id <~ ".").? ~ Id ~ ("(" ~> Id <~ ",") ~ BlkStmt <~ ")" ~ ";" ^^
+        { case rId ~ oId ~ id ~ macroId ~ blkStmt => lang.GenericProofCommand(id, List.empty, List((macroId, macroId.toString())), rId, oId, Some(blkStmt)) }
     }
 
     lazy val CmdBlock : PackratParser[List[GenericProofCommand]] = KwControl ~ "{" ~> rep(Cmd) <~ "}"

--- a/test/test-macro-1.ucl
+++ b/test/test-macro-1.ucl
@@ -26,5 +26,6 @@ module main {
         unroll(0);
         check;
         print_results;
+        print_module;
     }
 }

--- a/test/test-macro-9.ucl
+++ b/test/test-macro-9.ucl
@@ -1,0 +1,22 @@
+module main {
+    var x : integer;
+    
+    macro foo {
+        x = 2;
+    }
+
+    init {
+        foo;
+        assert(x == 10);
+    }
+    
+    control {
+        unroll(0);
+        check;
+        print_results;
+        assign_macro(foo, { x = 10; });
+        unroll(0);
+        check;
+        print_results;
+    }
+}

--- a/test/test-modify-macro.ucl
+++ b/test/test-modify-macro.ucl
@@ -1,0 +1,27 @@
+module main {
+    macro foo {
+        x = 0;
+    }
+
+    var x : integer;
+
+    init {
+        foo;
+        assert (x == 0);
+    }
+
+    control {
+        // First block
+        unroll (0);
+        check;
+        print_results;
+        // print_module;
+
+        // Second block
+        assign_macro(foo, { x = 1; });
+        unroll (0);
+        check;
+        print_results;
+        // print_module;
+    }
+}


### PR DESCRIPTION
Introduces an `assign_macro` command in the control block that changes the body of a macro.
e.g.
```
assign_macro(foo, { x = 1; y = 2; });
```
The commands in the control block are split into blocks at the commands that modify the module. The commands in each block are executed separately.