### PR TITLE
Groups: Add the ability to pass groups as input parameters to modules

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -35,6 +35,7 @@
   <logger name="uclid.lang.VariableDependencyFinder" level="OFF"/>
   <logger name="uclid.lang.VerificationExpressionCheckerPass" level="OFF"/>
   <logger name="uclid.lang.VerificationExpressionPass" level="OFF"/>
+  <logger name="uclid.lang.FiniteQuantsExpanderPass" level="OFF"/>
   <logger name="uclid.smt.Z3HornSolver" level="OFF"/>
   <logger name="uclid.smt.SExprLexical" level="OFF"/>
   <logger name="uclid.smt.SMTLIB2Base" level="OFF"/>

--- a/src/main/scala/uclid/lang/ModuleFlattener.scala
+++ b/src/main/scala/uclid/lang/ModuleFlattener.scala
@@ -263,8 +263,6 @@ class ModuleInstantiatorPass(module : Module, inst : InstanceDecl, targetModule 
     }.toList.flatten
   }
 
-  def createNextInputAssignments(varMap : VarMap) : List[Statement] = { List() }
-
   val (varMap, externalSymbolMap) = createVarMap()
   val targetInstVarMap = targetModule.getAnnotation[InstanceVarMapAnnotation].get.iMap
 
@@ -276,7 +274,6 @@ class ModuleInstantiatorPass(module : Module, inst : InstanceDecl, targetModule 
 
   val newVariables = createNewVariables(varMap)
   val newInputs = createNewInputs(varMap)
-  val newInputAssignments = createNextInputAssignments(varMap)
   val newAxioms = newModule.axioms.map {
     ax => {
       val idP = ax.id.flatMap(axId => Some(NameProvider.get(axId.toString() + "_axiom")))
@@ -359,7 +356,7 @@ class ModuleInstantiatorPass(module : Module, inst : InstanceDecl, targetModule 
   // add initialization for the instance.
   override def rewriteInit(init : InitDecl, context : Scope) : Option[InitDecl] = {
     newModule.init match {
-      case Some(initD) => Some(InitDecl(BlockStmt(List.empty, newInputAssignments ++ List(initD.body) ++ List(init.body))))
+      case Some(initD) => Some(InitDecl(BlockStmt(List.empty, List(initD.body) ++ List(init.body))))
       case None => Some(init)
     }
   }
@@ -384,7 +381,7 @@ class ModuleInstantiatorPass(module : Module, inst : InstanceDecl, targetModule 
   // rewrite module.
   override def rewriteModuleCall(modCall : ModuleCallStmt, context : Scope) : Option[Statement] = {
     if (modCall.id == inst.instanceId) {
-      Some(BlockStmt(List.empty, newInputAssignments ++ newNextStatements))
+      Some(BlockStmt(List.empty, newNextStatements))
     } else {
       Some(modCall)
     }

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -370,10 +370,10 @@ case class ExistsOp(vs: List[(Identifier, Type)], patterns: List[List[Expr]]) ex
 
 case class FiniteForallOp(id : (Identifier, Type), groupId : Identifier) extends QuantifiedBooleanOperator {
   override def variables = List.empty
-  override def toString = QuantifiedBooleanOperator.toString("finite_forall", List.empty, List.empty)
+  override def toString = "finite_forall %s : %s in %s".format(id._1, id._2, groupId)
 }
 case class FiniteExistsOp(id : (Identifier, Type), groupId : Identifier) extends QuantifiedBooleanOperator {
-  override def toString = QuantifiedBooleanOperator.toString("finite_exists", List.empty, List.empty)
+  override def toString = "finite_exists %s : %s in %s".format(id._1, id._2, groupId)
   override def variables = List.empty
 }
 

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -384,6 +384,9 @@ class GroupVerifSpec extends AnyFlatSpec {
   "test-group-3.ucl" should "verify one and fail one assertion." in {
     VerifierSpec.expectedFails("./test/test-group-3.ucl", 1)
   }
+  "test-group-4.ucl" should "verify one and fail one assertion." in {
+    VerifierSpec.expectedFails("./test/test-group-4.ucl", 1)
+  }
 }
 class ModuleVerifSpec extends AnyFlatSpec {
   "test-modules.ucl" should "verify all assertions." in {

--- a/test/test-group-4.ucl
+++ b/test/test-group-4.ucl
@@ -1,0 +1,34 @@
+module decl {
+    input myGroup : group(integer);
+
+    var a, b : boolean;
+
+    init {
+        a = finite_forall (int : integer) in myGroup :: int > -1; //Satisfied by grp
+        b = finite_exists (int : integer) in myGroup :: int < 0; //Not satisfied by grp
+    }
+
+    next {
+    }
+}
+
+module main {
+    group grp : integer = {0, 1, 2, 3};
+
+    instance declInst : decl(myGroup : (grp));
+
+    init {
+    }
+
+    next {
+    }
+
+    property f : declInst.a; //Should pass
+    property t : declInst.b; //Should fail
+
+    control {
+        v = unroll(0);
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
This commit required removing the extra
"<rest of varname>__bound_input" variables that get created by
ModuleInstantiatorPass.BoundInput. Doing so does not break any
existing tests.