### PR TITLE
factor out check Command and call check automatically

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -327,12 +327,11 @@ class SymbolicSimulator (module : Module) {
             check(solver, config, cmd);
             needToPrintResults=true
           case "check" => {
-            // deprecated command: do nothing because we printed results when we checked
+            // deprecated command: do nothing because we checked after every verification command
           } 
           case "print" =>
             UclidMain.printStatus(cmd.args(0)._1.asInstanceOf[StringLit].value)
           case "print_results" =>
-            // deprecated command: do nothing because we printed results when we checked
             dumpResults("print_results", defaultLog)
             printResults(proofResults, cmd.argObj, config)
             needToPrintResults=false


### PR DESCRIPTION
Factor out the code for "check", and make sure check is automatically called after every verification command

This avoids confusion when users write commands and then forget to write check, and uclid prints out a set of results that says all 0 assertions pass. 

Possible disadvantage: we have to start up the solver multiple times. I think this overhead will be small