### PR TITLE
Fix history + k-induction combination

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -1550,7 +1550,7 @@ class SymbolicSimulator (module : Module) {
       if (filter(prop.id, prop.params)) {
         val property = AssertInfo(
             prop.name, label, simTbl.map(ft => ft.clone()), scope, frameNumber+numberSteps, smt.BooleanLit(true),
-            evaluate(prop.expr, symbolTable, frameTbl, frameNumber, scope), prop.params, prop.expr.position)
+            evaluate(prop.expr, symbolTable, frameTbl, frameNumber+numberSteps, scope), prop.params, prop.expr.position)
         addAssert(property)
       }
     })

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -477,7 +477,7 @@ class SymbolicSimulator (module : Module) {
     frameList += symbolTable
     val simTbl : SimulationTable = ArrayBuffer(frameList)
 
-    if (addAssertions) { addAsserts(0, 0, symbolTable, frameList, simTbl, label, scope, propertyFilter, addAssertToTree _) }
+    if (addAssertions) { addAsserts(0, symbolTable, frameList, simTbl, label, scope, propertyFilter, addAssertToTree _) }
     else { assumeAssertions(symbolTable, frameTbl, 1, scope, propertyFilter, addAssumptionToTree _) }
   }
 
@@ -537,8 +537,8 @@ class SymbolicSimulator (module : Module) {
     val simTbl : SimulationTable = ArrayBuffer(frameList)
 
     if (addAssertions) {
-      addAsserts(1,0, symTab, frameList, simTbl, label, scope, noHyperInvariantFilter(propertyFilter), addAssertsToList _)
-      addAsserts(1,0, symTab, frameList, simTbl, label, scope, HyperInvariantFilter(propertyFilter), addHyperAssertsToList _)
+      addAsserts(1, symTab, frameList, simTbl, label, scope, noHyperInvariantFilter(propertyFilter), addAssertsToList _)
+      addAsserts(1, symTab, frameList, simTbl, label, scope, HyperInvariantFilter(propertyFilter), addHyperAssertsToList _)
     }
     if (addAssumptions) { assumeAssertions(symTab, frameList, 1, scope, assumptionFilter, addAssumesToList _) }
 
@@ -595,8 +595,8 @@ class SymbolicSimulator (module : Module) {
     assumesLength = assumes.length
 
     if (addAssertions) {
-      addAsserts(1,0, currentState, frameList, simTbl, label, scope, noHyperInvariantFilter(propertyFilter), addAssertsToList _)
-      addAsserts(1,0, currentState, frameList, simTbl, label, scope, HyperInvariantFilter(propertyFilter), addHyperAssertsToList _)
+      addAsserts(1, currentState, frameList, simTbl, label, scope, noHyperInvariantFilter(propertyFilter), addAssertsToList _)
+      addAsserts(1, currentState, frameList, simTbl, label, scope, HyperInvariantFilter(propertyFilter), addHyperAssertsToList _)
     }
     if (addAssertionsAsAssumes) { assumeAssertions(currentState, frameList, numPastFrames, scope, assumptionFilter, addAssumesToList _) }
     assumes.takeRight(assumes.length - assumesLength).foreach(expr => assumesLambda += expr)
@@ -1134,7 +1134,7 @@ class SymbolicSimulator (module : Module) {
       val simTbl = ArrayBuffer(frameList)
       // FIXME: simTable
       addModuleAssumptions(currentState, frameList, numPastFrames, scope, addAssumptionToTree _)
-      if (assertProperties) { addAsserts(step,startStep, currentState, frameList, simTbl, label, scope, propertyFilter, addAssertToTree _)  }
+      if (assertProperties) { addAsserts(step+startStep, currentState, frameList, simTbl, label, scope, propertyFilter, addAssertToTree _)  }
       else { assumeAssertions(currentState, frameList, numPastFrames, scope, propertyFilter, addAssumptionToTree _) }
     }
     symbolTable = currentState
@@ -1541,7 +1541,7 @@ class SymbolicSimulator (module : Module) {
   }
 
   /** Add module specifications (properties) to the list of proof obligations */
-  def addAsserts(frameNumber : Int, numberSteps: Int, symbolTable : SymbolTable, frameTbl : FrameTable, simTbl : SimulationTable,
+  def addAsserts(frameNumber : Int, symbolTable : SymbolTable, frameTbl : FrameTable, simTbl : SimulationTable,
                 label : String, scope : Scope, filter : ((Identifier, List[ExprDecorator]) => Boolean),
                 addAssert : (AssertInfo => Unit)) {
 
@@ -1549,8 +1549,8 @@ class SymbolicSimulator (module : Module) {
       val prop = module.properties.find(p => p.id == specVar.varId).get
       if (filter(prop.id, prop.params)) {
         val property = AssertInfo(
-            prop.name, label, simTbl.map(ft => ft.clone()), scope, frameNumber+numberSteps, smt.BooleanLit(true),
-            evaluate(prop.expr, symbolTable, frameTbl, frameNumber+numberSteps, scope), prop.params, prop.expr.position)
+            prop.name, label, simTbl.map(ft => ft.clone()), scope, frameNumber, smt.BooleanLit(true),
+            evaluate(prop.expr, symbolTable, frameTbl, frameNumber, scope), prop.params, prop.expr.position)
         addAssert(property)
       }
     })

--- a/src/test/scala/SMTLIB2Spec.scala
+++ b/src/test/scala/SMTLIB2Spec.scala
@@ -446,6 +446,9 @@ class SMTLIB2Spec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {
     SMTLIB2Spec.expectedFails("./test/test-history-1.ucl", 0)
   }
+  "test-history-2.ucl" should "verify all assertions." in {
+    SMTLIB2Spec.expectedFails("./test/test-history-2.ucl", 1)
+  }
   // "test-ltl-0-safe.ucl" should "verify all assertions." in {
   //   SMTLIB2Spec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
   // }

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -499,6 +499,9 @@ class LTLVerifSpec extends AnyFlatSpec {
   "test-history-1.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-history-1.ucl", 0)
   }
+  "test-history-2.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-history-2.ucl", 1)
+  }
   // "test-ltl-0-safe.ucl" should "verify all assertions." in {
   //   VerifierSpec.expectedFails("./test/test-ltl-0-safe.ucl", 0)
   // }

--- a/test/test-history-2.ucl
+++ b/test/test-history-2.ucl
@@ -1,0 +1,28 @@
+module main {
+
+	var cpt,oldcpt : integer ;
+	
+	init {
+		cpt=0;
+	}
+  
+	next {
+		cpt'= cpt+1;
+		oldcpt'=cpt;
+	}
+
+// should pass
+	invariant pass0 : (cpt>1) ==> (history(cpt,1)==oldcpt) ;
+// should fail
+	invariant fail0 : (cpt<=1) ==> (history(cpt,1)==oldcpt) ;
+
+
+	control {
+		vobj = induction(2);
+		check;
+		print_results;
+ 		vobj.print_cex(cpt,oldcpt);
+	}
+	
+}
+


### PR DESCRIPTION
This is a fix for issue https://github.com/uclid-org/uclid/issues/145

The idToSMT function gets the correct SMT ID for a given ID by computing current frame number  - past. We were passing the wrong frame number to this function when symbolic simulate starts at a frame number other than 0 (this is a similar bug to https://github.com/uclid-org/uclid/issues/143).

