### PR TITLE
Only try to split list of commands if commands are not empty

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -163,10 +163,13 @@ object UclidMain {
       val mainModule = instantiate(config, modules, mainModuleName)
       mainModule match {
         case Some(m) =>
-          // Split the control block commands to blocks on commands that modify the module
-          val cmdBlocks = splitCommands(m.cmds)
-          // Execute the commands for each block
-          cmdBlocks.foreach(cmdBlock => executeCommands(m, cmdBlock, config, mainModuleName))
+          if(!m.cmds.isEmpty)
+          {
+            // Split the control block commands to blocks on commands that modify the module
+            val cmdBlocks = splitCommands(m.cmds)
+            // Execute the commands for each block
+            cmdBlocks.foreach(cmdBlock => executeCommands(m, cmdBlock, config, mainModuleName))
+          }
         case None    =>
           throw new Utils.ParserError("Unable to find main module", None, None)
       }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -887,5 +887,10 @@ class ParserSpec extends AnyFlatSpec {
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
+  "test-no-control-block.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-no-control-block.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
 
 }

--- a/test/test-no-control-block.ucl
+++ b/test/test-no-control-block.ucl
@@ -1,0 +1,11 @@
+// checks we can parse a file without a control block
+// in the main module without throwing ugly errors
+module main {
+  var y: integer;
+
+  procedure foo()
+    modifies y;
+  {
+    y = 0;
+  }
+}


### PR DESCRIPTION
If no commands in main module, we can just return after parsing