### PR TITLE
Printed smt files with pos and concat modules

### DIFF
--- a/src/main/scala/uclid/AssertionTree.scala
+++ b/src/main/scala/uclid/AssertionTree.scala
@@ -176,6 +176,7 @@ class AssertionTree {
           solver.assert(checkExpr)
           solver.curAssertName = e.name
           solver.curAssertLabel = e.label
+          solver.curAssertPos = e.pos.toString.replace('.', '_').replace('/', '_').replace(',','_')
           val sat = solver.check(getModel)
           val delta =  (System.nanoTime() - start) / 1000000.0
           UclidMain.printStats(f"Solver finished in $delta%.1f ms")

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -348,8 +348,8 @@ object UclidMain {
           (acc, module) => {
             val declsP = (acc.decls ++ module.decls)
             val cmdsP = (acc.cmds ++ module.cmds)
-            // since the notes are empty, it's okay to remove the duplicates
             Utils.assert(module.notes.size == 1 && module.notes.head.asInstanceOf[InstanceVarMapAnnotation].iMap.size == 0, "Expected module to initially have empty annotations.")
+            // since the notes (list of annotations of the modules) are default values, it's okay to remove the duplicates in the line below
             val notesP = (acc.notes ++ module.notes).distinct
             Module(id, declsP, cmdsP, notesP)
           }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -346,8 +346,10 @@ object UclidMain {
         val modules = kv._2
         val combinedModule = modules.foldLeft(Module(id, List.empty, List.empty, List.empty)){
           (acc, module) => {
-            val declsP = (acc.decls ++ module.decls).distinct
-            val cmdsP = (acc.cmds ++ module.cmds).distinct
+            val declsP = (acc.decls ++ module.decls)
+            val cmdsP = (acc.cmds ++ module.cmds)
+            // since the notes are empty, it's okay to remove the duplicates
+            Utils.assert(module.notes.size == 1 && module.notes.head.asInstanceOf[InstanceVarMapAnnotation].iMap.size == 0, "Expected module to initially have empty annotations.")
             val notesP = (acc.notes ++ module.notes).distinct
             Module(id, declsP, cmdsP, notesP)
           }

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -344,6 +344,9 @@ object UclidMain {
       .map((kv) => {
         val id = kv._1
         val modules = kv._2
+        if (modules.size > 1) {
+          UclidMain.printStatus("Multiple definitions for module " + modules.head.id.toString() + " were found and have been combined.")
+        }
         val combinedModule = modules.foldLeft(Module(id, List.empty, List.empty, List.empty)){
           (acc, module) => {
             val declsP = (acc.decls ++ module.decls)

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -339,22 +339,35 @@ object UclidMain {
     }
 
     // combine all modules with the same name
-    val parsedModulesP = parsedModules
+    val combinedParsedModules = parsedModules
       .groupBy(_.id)
       .map((kv) => {
         val id = kv._1
         val modules = kv._2
-        modules.foldLeft(Module(id, List.empty, List.empty, List.empty)){
-          (acc, module) => Module(id, acc.decls++module.decls, acc.cmds++module.cmds, acc.notes++module.notes)
+        val combinedModule = modules.foldLeft(Module(id, List.empty, List.empty, List.empty)){
+          (acc, module) => {
+            val declsP = (acc.decls ++ module.decls).distinct
+            val cmdsP = (acc.cmds ++ module.cmds).distinct
+            val notesP = (acc.notes ++ module.notes).distinct
+            Module(id, declsP, cmdsP, notesP)
+          }
         }
+        id -> combinedModule
       })
+      .toMap
+    // restore ordering of modules
+    val combinedParsedModulesP = parsedModules
+      .map(module => module.id)
+      .distinct
+      .map(id => combinedParsedModules.get(id).get)
+      .toList
 
     // now process each module
     val init = (List.empty[Module], Scope.empty)
     // NOTE: The foldLeft/:: combination here reverses the order of modules.
     // The PassManager in instantiate calls run(ms : List[Module]); this version of run uses foldRight.
     // So modules end up being processed in the same order in both PassManagers.
-    val processedModules = parsedModulesP.foldLeft(init) {
+    val processedModules = combinedParsedModulesP.foldLeft(init) {
       (acc, m) =>
         val modules = acc._1
         val context = acc._2

--- a/src/main/scala/uclid/smt/Context.scala
+++ b/src/main/scala/uclid/smt/Context.scala
@@ -116,6 +116,7 @@ abstract trait Context {
   var filePrefix = ""
   var curAssertName = ""
   var curAssertLabel = ""
+  var curAssertPos = ""
 
   /** Flatten a type and add it to the type synonym map. */
   def flatten(typ: Type, synMap: SynonymMap) : (Type, SynonymMap) = {

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -518,8 +518,7 @@ class Z3Interface() extends Context {
       }
       return checkResult
     } else {
-      // Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n(get-info :all-statistics)\n")
-      Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertPos%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n")
+      Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertPos%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n(get-info :all-statistics)\n")
       counten += 1
       return SolverResult(None, None)
     }

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -518,7 +518,8 @@ class Z3Interface() extends Context {
       }
       return checkResult
     } else {
-      Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n(get-info :all-statistics)\n")
+      // Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n(get-info :all-statistics)\n")
+      Utils.writeToFile(f"$filePrefix%s-$curAssertName%s-$curAssertPos%s-$curAssertLabel%s-$counten%04d.smt", smtOutput + "\n\n(check-sat)\n")
       counten += 1
       return SolverResult(None, None)
     }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -49,7 +49,7 @@ class ParserSpec extends AnyFlatSpec {
     try {
       val filename = "test/test-type1.ucl"
       val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
-      assert (fileModules.size == 2)
+      assert (fileModules.size == 1)
     }
     catch {
       case p : Utils.ParserErrorList =>
@@ -229,6 +229,24 @@ class ParserSpec extends AnyFlatSpec {
         assert (p.errors.exists(p => p._1.contains("Identifier was not declared modifiable: x")))
         assert (p.errors.exists(p => p._1.contains("Identifier cannot be declared modifiable: z")))
     }
+  }
+  "test-concat-modules-dup-decl.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-concat-modules-dup-decl.ucl"), lang.Identifier("main"))
+      // should never get here.
+      assert (false);
+    }
+    catch {
+      // this list has all the errors from parsing
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size == 2)
+        assert (p.errors.exists(p => p._1.contains("Redeclaration of identifier 'x'.")))
+    }
+  }
+  "test-concat-modules.ucl" should "parse successfully" in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-concat-modules.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
   }
   "test-mod-set-analysis-0.ucl" should "parse successfully." in {
     val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-0.ucl"), lang.Identifier("main"))

--- a/test/test-concat-modules-dup-decl.ucl
+++ b/test/test-concat-modules-dup-decl.ucl
@@ -1,0 +1,17 @@
+/* Test that multiple conflicting declarations for the same module results in an error.
+*/
+module main {
+    var x: integer;
+    var x: integer;
+
+}
+
+module main {
+    var x: bv5;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-concat-modules.ucl
+++ b/test/test-concat-modules.ucl
@@ -1,0 +1,44 @@
+/* Test where variable declarations, init and next blocks are in different declaring modules.
+*/
+module A_minor {
+    var t: integer;
+}
+
+module A {
+    instance minor: A_minor();
+}
+
+module A {
+    var x, y, z: integer;
+}
+
+module A {
+    init {
+        x = 0;
+        y = 0;
+        z = 0;
+    }
+}
+
+module A {
+    next {
+        x' = x;
+        y' = y;
+        z' = z;
+    }
+}
+
+module main {
+    instance a: A();
+    invariant same_x: a.x == 0;
+    invariant same_y: a.y == 0;
+    invariant same_z: a.z == 0;
+    next {
+        next(a);
+    }
+    control {
+        v = induction();
+        check;
+        print_results; 
+    }
+}


### PR DESCRIPTION
Two main changes:

(1) Added the position (underscore separated) to the filename of printed SMT queries (using the -g option).
(2) New feature to concatenate declarations of modules of the same name after the parsing step. After this, multiple definitions of a module will be allowed because they will be concatenated.

Motivation for (2):

Using import statements that are specific to each type is cumbersome when a lot of the definitions are shared and you want to quickly switch out module definitions without having to rewrite all the import statements for every combination of models you want to create. We also do not have an option to switch out init and next blocks and all of these need to be hand written.

See below for an example with a main module A.ucl and two implementations of the `compute` function in AImpl1.ucl and AImpl2.ucl.

------ filename: A.ucl ------
// Shared code for implementation 1 and 2 that uses the `compute` define declaration below
module A {
    ...
}
// Main module of A.ucl
module main {
    ...
}

------ filename: AImpl1.ucl ------
// Implementation 1; compute adds
module A {
  define compute(x: integer, y: integer): integer = x + y;
}

------ filename: AImpl2.ucl ------
// Implementation 2; compute multiples
module A {
  define compute(x: integer, y: integer): integer = x * y;
}

To run both implementations, I only need to pair them accordingly as uclid5 arguments:

`uclid A.ucl AImpl1.ucl` and `uclid A.ucl AImpl2.ucl`

To clarify, this feature does not only apply for macros but any type of declaration, including init and next blocks. Thus, if you want to check different combinations of init and next blocks, you can simply declare them in different modules and files and then combine them via UCLID's arguments as shown above instead of writing a UCLID model for each combination.

Note: Initially, the annotations list of a module is initialized with an empty InstanceVarMapAnnotation and concatenating the list of annotations would leave duplicate InstanceVarMapAnnotions in the list of annotations of a module. This breaks the invariant that there should only be one. Since the map is initially empty, distinct() is called on the annotations after concatenating.