### PR TITLE
Fixed modifies set analysis bug.

### DIFF
--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -229,7 +229,6 @@ object UclidMain {
     passManager.addPass(new ModuleSynthFunctionsImportRewriter())
     // automatically compute modifies set
     if (config.modSetAnalysis) {
-        passManager.addPass(new ModSetAnalysis())
         passManager.addPass(new ModSetRewriter())
     }
     // collects external types to the current module (e.g., module.mytype)

--- a/src/main/scala/uclid/lang/ModSetAnalysis.scala
+++ b/src/main/scala/uclid/lang/ModSetAnalysis.scala
@@ -39,106 +39,56 @@
 package uclid
 package lang
 
-class ModSetAnalysisPass() extends ReadOnlyPass[Map[Identifier, Set[Identifier]]] {
-  // Map from procedure id to its inferred modifies set.
-  type T = Map[Identifier, Set[Identifier]]
-
-  /** Returns whether the variable should be added to the modifies set using the
-    * state variable set and current local variable set.
-    *  @param varIdSet The set of state variables to include in the modifies set.
-    *                  This is usually the set of output and state variables.
-    *  @param locVarIdSet The set of local variables at the current scope.
-    *                     This is used to avoid adding shadowed local variables.
-    */
-  def isModified(id: Identifier, varIdSet: Set[Identifier], locVarIdSet: Set[Identifier]): Boolean = {
-    varIdSet.contains(id) && !locVarIdSet.contains(id)
-  }
-
-  /** Recursively computes the modifies set for a statement by looking at the
-   *  left hand side assignments and havoc statements.
-   *
-   *  @param stmt The statement to infer
-   *  @param varIdSet The set of state variables to include in the modifies set.
-   *                  This is usually the set of output and state variables.
-   *  @param locVarIdSet The set of local variables at the current scope.
-   *                     This is used to avoid adding shadowed local variables.
-   */
-  def collectStatementModifies(stmt: Statement, varIdSet: Set[Identifier], locVarIdSet: Set[Identifier]): Set[Identifier] = {
-    stmt match {
-        case HavocStmt(havocableEntity) => {
-            havocableEntity match {
-                case HavocableId(id) => if (isModified(id, varIdSet, locVarIdSet)) Set(id) else Set.empty
-                case _ => Set.empty
-            }
-        }
-        case AssignStmt(lhss, _) => {
-          lhss.map(lhs => lhs.ident)
-              .filter(id => isModified(id, varIdSet, locVarIdSet))
-              .foldLeft(List.empty[Identifier])((acc, id) => id :: acc)
-              .toSet
-        }
-        case BlockStmt(vars, stmts) => {
-          val locVarIdSetP = vars.foldLeft(locVarIdSet)((acc, bvd) => acc ++ bvd.ids.toSet)
-          stmts.foldLeft(Set.empty[Identifier])((acc, stmt) => acc ++ collectStatementModifies(stmt, varIdSet, locVarIdSetP))
-        }
-        case IfElseStmt(_, thn, els) => collectStatementModifies(thn, varIdSet, locVarIdSet) ++ collectStatementModifies(els, varIdSet, locVarIdSet)
-        case ForStmt(_, _, _, body) => collectStatementModifies(body, varIdSet, locVarIdSet)
-        case WhileStmt(_, body, _) => collectStatementModifies(body, varIdSet, locVarIdSet)
-        case CaseStmt(body) => body.map(pair => collectStatementModifies(pair._2, varIdSet, locVarIdSet)).flatten.toSet
-        case ProcedureCallStmt(id, lhss, _, instanceId, _) => {
-          if (instanceId.isDefined) {
-            throw new Utils.UnimplementedException("Modifies set analysis is unimplemented for instance procedure calls.");
-          }
-          lhss.map(lhs => lhs.ident)
-              .filter(isModified(_, varIdSet, locVarIdSet))
-              .foldLeft(List.empty[Identifier])((acc, id) => id :: acc)
-              .toSet
-        }
-        case _ => Set.empty
-    }
-  }
-
-  override def applyOnProcedure(d : TraversalDirection.T, proc : ProcedureDecl, in : T, context : Scope) : T = {
-    val stateVarIds = context.vars.map(v => v.varId)
-    val outputVarIds = context.outputs.map(v => v.outId)
-    val varIdSet = stateVarIds ++ outputVarIds
-    val returnIdSet = proc.sig.outParams.map(_._1).toSet
-    val modSet = collectStatementModifies(proc.body, varIdSet, returnIdSet)
-    in + (proc.id -> modSet)
-  }
-}
-
-class ModSetAnalysis() extends ASTAnalyzer("ModSetAnalysis", new ModSetAnalysisPass()) {
-  override def reset() {
-    in = Some(Map.empty[Identifier, Set[Identifier]])
-  }
-
-  /** Visit the module and infer the writesets using the left hand side assignments and havocs.
-   *  Also updates the output to be a map from the procedure id to the inferred modifies set.
-   */
-  override def visit(module : Module, context : Scope) : Option[Module] = {
-    val modSetMap = visitModule(module, Map.empty[Identifier, Set[Identifier]], context)
-    _out = Some(modSetMap)
-    return Some(module)
-  }
-}
-
 class ModSetRewriterPass() extends RewritePass {
+    /*  A map that collects all the modified variables for a procedure.
+     *  The key is the procedure identifier and value is the set of mdoified variables.
+     */
+    var modSetMap: Map[Identifier, Set[ModifiableEntity]] = Map.empty[Identifier, Set[ModifiableEntity]]
+
+    /** Returns whether the variable should be added to the modifies set using the
+      * state variable set and current local variable set.
+      * We want to include variables that are
+      *   (1) contained in the variable set and
+      *   (2) not a local variable
+      *  @param varIdSet The set of state variables to include in the modifies set.
+      *                  This is usually the set of output and state variables.
+      *  @param locVarIdSet The set of local variables at the current scope.
+      *                     This is used to avoid adding shadowed local variables.
+      */
+    def isModified(id: Identifier, varIdSet: Set[Identifier], locVarIdSet: Set[Identifier]): Boolean = {
+      varIdSet.contains(id) && !locVarIdSet.contains(id)
+    }
+
     /** Returns the modified variables in a statement
      *  @stmt The statement whose write set is being inferred.
      *  @modSetMap The modifies set map inferred by the ModSetAnalysis pass. Should contain a map from procedures to thier inferred modifies sets.
      */
-    def getStmtModSet(stmt: Statement, modSetMap: Map[Identifier, Set[Identifier]]): Set[ModifiableId] = stmt match {
-      case BlockStmt(_, stmts) => stmts.foldLeft(Set.empty[ModifiableId])((acc, stmt) => acc ++ getStmtModSet(stmt, modSetMap))
-      case ProcedureCallStmt(id, _, _, _, _) => modSetMap.get(id) match {
-        case Some(set) => set.map(ident => ModifiableId(ident)).toSet
-        case None => Set.empty[ModifiableId]
+    def getStmtModSet(stmt: Statement, modSetMap: Map[Identifier, Set[ModifiableEntity]], varIdSet: Set[Identifier], locVarIdSet: Set[Identifier]): Set[ModifiableEntity] = stmt match {
+      case BlockStmt(vars, stmts) => {
+        val locVarIdSetP = vars.foldLeft(locVarIdSet)((acc, bvd) => acc ++ bvd.ids.toSet)
+        stmts.foldLeft(Set.empty[ModifiableEntity])((acc, stmt) => acc ++ getStmtModSet(stmt, modSetMap, varIdSet, locVarIdSetP))
       }
-      case IfElseStmt(_, ifblock, elseblock) => getStmtModSet(ifblock, modSetMap) ++ getStmtModSet(elseblock, modSetMap)
-      case ForStmt(_, _, _, body) => getStmtModSet(body, modSetMap)
-      case WhileStmt(_, body, _) => getStmtModSet(body, modSetMap)
-      case CaseStmt(body) => body.foldLeft(Set.empty[ModifiableId])((acc, pair) => acc ++ getStmtModSet(pair._2, modSetMap))
-      case _ => Set.empty[ModifiableId]
+      case ProcedureCallStmt(id, _, _, _, _) => modSetMap.get(id) match {
+        case Some(set) => set
+        case None => Set.empty[ModifiableEntity]
+      }
+      case IfElseStmt(_, ifblock, elseblock) => getStmtModSet(ifblock, modSetMap, varIdSet, locVarIdSet) ++ getStmtModSet(elseblock, modSetMap, varIdSet, locVarIdSet)
+      case ForStmt(_, _, _, body) => getStmtModSet(body, modSetMap, varIdSet, locVarIdSet)
+      case WhileStmt(_, body, _) => getStmtModSet(body, modSetMap, varIdSet, locVarIdSet)
+      case CaseStmt(body) => body.foldLeft(Set.empty[ModifiableEntity])((acc, pair) => acc ++ getStmtModSet(pair._2, modSetMap, varIdSet, locVarIdSet))
+      case HavocStmt(havocableEntity) => {
+          havocableEntity match {
+              case HavocableId(id) => if (isModified(id, varIdSet, locVarIdSet)) Set(ModifiableId(id)) else Set.empty
+              case _ => Set.empty
+          }
+      }
+      case AssignStmt(lhss, _) => {
+        lhss.map(lhs => lhs.ident)
+            .filter(id => isModified(id, varIdSet, locVarIdSet))
+            .foldLeft(List.empty[ModifiableEntity])((acc, id) => ModifiableId(id) :: acc)
+            .toSet
+      }
+      case _ => Set.empty[ModifiableEntity]
     }
 
     /** Rewrites the modifies set to contain all left hand side and havoced variables
@@ -147,15 +97,23 @@ class ModSetRewriterPass() extends RewritePass {
         set to the current modifies set if any exists.
      */
     override def rewriteProcedure(proc : ProcedureDecl, ctx : Scope) : Option[ProcedureDecl] = {
-        val modSetMap = analysis.manager.pass("ModSetAnalysis").asInstanceOf[ModSetAnalysis].out.get
         val inferredModSet = modSetMap.get(proc.id) match {
-            case Some(set) => set.map(ident => ModifiableId(ident))
+            case Some(set) => set
             case None => Set.empty[ModifiableEntity]
         }
-        val calleeModSets = getStmtModSet(proc.body, modSetMap)
+        val stateVarIds = ctx.vars.map(v => v.varId)
+        val outputVarIds = ctx.outputs.map(v => v.outId)
+        val varIdSet = stateVarIds ++ outputVarIds
+        val returnIdSet = proc.sig.outParams.map(_._1).toSet
+        val calleeModSets = getStmtModSet(proc.body, modSetMap, varIdSet, returnIdSet)
         val modSet = proc.modifies
-        // combined modifies set containing the original modifies set, inferred modifies set, and modifies set of the callees
+        // combined modifies set containing the original modifies set, inferred modifies set
+        // and modifies set of the callees
         val combinedModSet = modSet ++ inferredModSet ++ calleeModSets
+        // update the modifies sets for all functions
+        // this is important for the next iteration of the rewrite pass since it is repeated
+        // until a fixed point where no additional modified identifiers are found
+        modSetMap = modSetMap + (proc.id -> combinedModSet)
         Some(ProcedureDecl(proc.id, proc.sig, proc.body, proc.requires, proc.ensures, combinedModSet, proc.annotations))
     }
 }

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -268,6 +268,11 @@ class ParserSpec extends AnyFlatSpec {
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
     assert (instantiatedModules.size == 1)
   }
+  "test-mod-set-analysis-6.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfigWithMSA("test/test-mod-set-analysis-6.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
   "test-mutual-recursion-error.ucl" should "not parse successfully." in {
     try {
       val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-mutual-recursion-error.ucl"), lang.Identifier("main"))

--- a/test/test-mod-set-analysis-6.ucl
+++ b/test/test-mod-set-analysis-6.ucl
@@ -1,0 +1,46 @@
+module main {
+    var x, y: integer;
+    type cache_t = [integer]boolean;
+    const init_cache: cache_t;
+    var cache: cache_t;
+
+    procedure [inline] update_cache()
+        modifies cache;
+        // infers cache
+    {
+        cache = init_cache;
+    }
+
+    procedure bar()
+        modifies y;
+        // infers x, y
+        // add y
+        // add x and y
+        // add cache
+    {
+        call update_cache();
+        y = 0;
+        x = 0;
+    }
+
+    procedure foo()
+        modifies y;
+        // infers y
+        // modifies cache not injected
+    {
+        y = 0;
+        call bar();
+    }
+
+    next {
+        call foo();
+    }
+
+    invariant test: true;
+
+    control {
+        v = induction;
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
Preivously the rewriter would not recursively compute the modifies set
until a fixed point. Test test/test-mod-set-analysis-6.ucl now works as
a result of this fix.