### PR TITLE
fix hyperselect check

### DIFF
--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -589,6 +589,12 @@ class HyperPropertySpec extends AnyFlatSpec {
   "test-hyperproperty-4.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-hyperproperty-4.ucl", 0)
   }
+  "test-hyperproperty-6.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-hyperproperty-6.ucl", 0)
+  }
+  "test-hyperproperty-7.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-hyperproperty-7.ucl", 0)
+  }
 }
 
 object PrintCexSpec {

--- a/test/test-hyperproperty-6.ucl
+++ b/test/test-hyperproperty-6.ucl
@@ -1,0 +1,29 @@
+module a
+{
+    var x, y : integer;
+
+    init {
+      y = x + 1;
+    }
+
+    next {
+      y' = y + 1;
+    }
+}
+
+
+module main
+{
+    instance a_mod : a();
+
+    hyperaxiom[2] x_eq: a_mod.x.1 == a_mod.x.2;
+    hyperinvariant[2] det_xy: a_mod.y.1 == a_mod.y.2;
+
+    control {
+        v = unroll(5);
+        check;
+        print_results;
+        v.print_cex(a_mod.x, a_mod.y);
+    }
+}
+

--- a/test/test-hyperproperty-7.ucl
+++ b/test/test-hyperproperty-7.ucl
@@ -1,0 +1,30 @@
+module a
+{
+    var x: [integer]integer;
+    var y: integer;
+
+    init {
+      y = x[0] + 1;
+    }
+
+    next {
+      y' = y + 1;
+    }
+}
+
+
+module main
+{
+    instance a_mod : a();
+
+    hyperaxiom[2] x_eq: a_mod.x[0].1 == a_mod.x[0].2;
+    hyperinvariant[2] det_xy: a_mod.y.1 == a_mod.y.2;
+
+    control {
+        v = unroll(5);
+        check;
+        print_results;
+        v.print_cex(a_mod.x, a_mod.y);
+    }
+}
+


### PR DESCRIPTION
previously threw spurious errors on nested operands