### PR TITLE
UclidLang for record update operation and constant records (proper)

### DIFF
--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -848,6 +848,7 @@ class SymbolicSimulator (module : Module) {
       case smt.BitVectorLit(bv, w) => List()
       case smt.EnumLit(id, eTyp) => List()
       case smt.ConstArray(v, arrTyp) => List()
+      case smt.ConstRecord(fs) => List()
       case smt.MakeTuple(args) => args.flatMap(e => getHyperSelects(e))
       case opapp : smt.OperatorApplication =>
         val op = opapp.op
@@ -920,6 +921,7 @@ class SymbolicSimulator (module : Module) {
       case smt.BitVectorLit(bv, w) => List()
       case smt.EnumLit(id, eTyp) => List()
       case smt.ConstArray(v, arrTyp) => List()
+      case smt.ConstRecord(fs) => List()
       case smt.MakeTuple(args) => args.flatMap(e => getHavocs(e))
       case opapp : smt.OperatorApplication =>
         val op = opapp.op
@@ -1009,6 +1011,7 @@ class SymbolicSimulator (module : Module) {
       case smt.BitVectorLit(bv, w) => e
       case smt.EnumLit(id, eTyp) => e
       case smt.ConstArray(exp, arrTyp) => smt.ConstArray(_substitute(exp, sym), arrTyp)
+      case smt.ConstRecord(fs) => smt.ConstRecord(fs.map(f => (f._1, _substitute(f._2, sym))))
       case smt.MakeTuple(args) => smt.MakeTuple(args.map(e => _substitute(e, sym)))
       case opapp : smt.OperatorApplication =>
         val op = opapp.op
@@ -1489,6 +1492,8 @@ class SymbolicSimulator (module : Module) {
         opapp.operands.forall(arg => isStatelessExpr(arg, context + opapp.op))
       case a : ConstArray =>
         isStatelessExpr(a.exp, context)
+      case r: ConstRecord => 
+        r.fieldvalues.forall(f => isStatelessExpr(f._2, context))
       case fapp : FuncApplication =>
         isStatelessExpr(fapp.e, context) && fapp.args.forall(a => isStatelessExpr(a, context))
       case lambda : Lambda =>

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -56,7 +56,6 @@ import scala.util.parsing.input.NoPosition
 
 import org.json4s._
 import org.json4s.JsonDSL._
-import org.json4s.JsonDSL.WithBigDecimal._
 import org.json4s.jackson.JsonMethods._
 import scala.collection.mutable
 
@@ -1275,14 +1274,14 @@ class SymbolicSimulator (module : Module) {
     // Get each counterexample trace
     val jsonobj : JObject = JObject(results.filter(res => labelMatches(res.assert) && res.result.isModelDefined).map{(result) => {
       val prop_name : String = result.assert.name.split("\\s+").mkString("__")
-      ((prop_name ++ "__" ++ prop_counter.incrCount(prop_name).toString()) 
+      ((prop_name + "__" + prop_counter.incrCount(prop_name).toString()) 
         -> printCEXJSON(result, exprs))
     }})
     // Write counterexample trace
     if (jsonobj.values.size > 0) {
       val filename : String = config.jsonCEXfile.isEmpty match {
         case true => "cex.json"
-        case false => (config.jsonCEXfile ++ ".json")
+        case false => (config.jsonCEXfile + ".json")
       }
       val fh  = new File(filename)
       val bw  = new BufferedWriter(new FileWriter(fh))
@@ -1404,7 +1403,7 @@ class SymbolicSimulator (module : Module) {
     exprs.foreach { (e) => {
       try {
         val result = m.evalAsString(evaluate(e._1.id, f, frameTbl, frameNumber, scope))
-        val value = (Try(if (result.toBoolean) BigInt(1) else BigInt(0)).toOption ++ Try(BigInt(result)).toOption).head
+        val value = (Try(if (result.toBoolean) BigInt(1) else BigInt(0)).toOption.++:(Try(BigInt(result)).toOption)).head
         vcd.wireChanged(e._2, value)
       } catch {
         case excp : Utils.UnknownIdentifierException =>
@@ -1482,6 +1481,10 @@ class SymbolicSimulator (module : Module) {
         inds.forall(ind => isStatelessExpr(ind, context)) &&
         args.forall(arg => isStatelessExpr(arg, context)) &&
         isStatelessExpr(value, context)
+      case OperatorApplication(RecordUpdate(ind, value), args) =>
+        isStatelessExpr(ind, context) && 
+        isStatelessExpr(value, context) &&
+        args.forall(arg => isStatelessExpr(arg, context))
       case opapp : OperatorApplication =>
         opapp.operands.forall(arg => isStatelessExpr(arg, context + opapp.op))
       case a : ConstArray =>
@@ -1688,19 +1691,10 @@ class SymbolicSimulator (module : Module) {
       }
     }
 
-    // Helper function to read from a record.
-    def recordSelect(field : String, rec : smt.Expr) = {
-      smt.OperatorApplication(smt.RecordSelectOp(field), List(rec))
-    }
-    // Helper function to update a record.
-    def recordUpdate(field : String, rec : smt.Expr, newVal : smt.Expr) = {
-      smt.OperatorApplication(smt.RecordUpdateOp(field), List(rec, newVal))
-    }
-
     def simulateRecordUpdateExpr(st : smt.Expr, fields : List[String], newVal : smt.Expr) : smt.Expr = {
       fields match {
         case hd :: tl =>
-          recordUpdate(hd, st, simulateRecordUpdateExpr(recordSelect(hd, st), tl, newVal))
+          smt.Converter.recordUpdate(hd, st, simulateRecordUpdateExpr(smt.Converter.recordSelect(hd, st), tl, newVal))
         case Nil =>
           newVal
       }

--- a/src/main/scala/uclid/lang/ASTVistors.scala
+++ b/src/main/scala/uclid/lang/ASTVistors.scala
@@ -1121,6 +1121,8 @@ class ASTAnalyzer[T] (_passName : String, _pass: ReadOnlyPass[T]) extends ASTAna
         result = inds.foldLeft(result)((acc, ind) => visitExpr(ind, acc, context))
       case ArrayUpdate(inds, value) =>
         result = inds.foldLeft(visitExpr(value, result, context))((acc, ind) => visitExpr(ind, acc, context))
+      case RecordUpdate(id, expr) =>
+        result = visitIdentifier(id, visitExpr(expr, result, context), context)
       case _ =>
     }
     result = pass.applyOnOperator(TraversalDirection.Up, op, result, context)
@@ -2310,6 +2312,15 @@ class ASTRewriter (_passName : String, _pass: RewritePass, setFilename : Boolean
           case Some(vP) => Some(ArrayUpdate(indsP, vP))
           case None => None
         }
+      case RecordUpdate(id, expr) => {
+        visitIdentifier(id, context) match {
+          case Some(idP) => visitExpr(expr, context) match {
+            case Some(exprP) => Some(RecordUpdate(idP, exprP))
+            case None => None
+          }
+          case None => None
+        }
+      }
       case _ =>
         pass.rewriteOperator(op, context)
     }

--- a/src/main/scala/uclid/lang/ModularProductProgram.scala
+++ b/src/main/scala/uclid/lang/ModularProductProgram.scala
@@ -428,7 +428,8 @@ class ModularProductProgramPass extends RewritePass {
                     }
                 case ConstArray(_, _) =>
                     throw new Utils.UnimplementedException("Type ConstArray not supported.")
-
+                case ConstRecord(_) => 
+                    throw new Utils.UnimplementedException("Type ConstRecord not supported.")
                 case Tuple(values) => Tuple(values.map(getRenamedExpr(_, context, copy)))
 
                 case OperatorApplication(op, operands) =>  op match {

--- a/src/main/scala/uclid/lang/ModularProductProgram.scala
+++ b/src/main/scala/uclid/lang/ModularProductProgram.scala
@@ -441,8 +441,11 @@ class ModularProductProgramPass extends RewritePass {
                         val newindices = indices.map(getRenamedExpr(_, context, copy))
                         val newVal = getRenamedExpr(value, context, copy)
                         OperatorApplication(ArrayUpdate(newindices,newVal),operands.map(getRenamedExpr(_, context, copy)))
+                    case RecordUpdate(id, expr) =>
+                        val newExpr = getRenamedExpr(expr, context, copy)
+                        OperatorApplication(RecordUpdate(id,newExpr), operands.map(getRenamedExpr(_, context, copy)))
                     case _ => OperatorApplication(op, operands.map(getRenamedExpr(_, context, copy)))
-                    }   
+                }
 
                 case FuncApplication(e, args) => FuncApplication(e, args.map(getRenamedExpr(_, context, copy)))
                 

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -120,6 +120,8 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
         opapp.operands.forall(arg => isStatelessExpr(arg, context + opapp.op))
       case a : ConstArray =>
         isStatelessExpr(a.exp, context)
+      case r : ConstRecord =>
+        r.fieldvalues.forall(f => isStatelessExpr(f._2, context))
       case fapp : FuncApplication =>
         isStatelessExpr(fapp.e, context) && fapp.args.forall(a => isStatelessExpr(a, context))
       case lambda : Lambda =>

--- a/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
+++ b/src/main/scala/uclid/lang/ModuleDefinesImportCollector.scala
@@ -113,6 +113,9 @@ class ModuleDefinesImportCollectorPass extends ReadOnlyPass[List[Decl]] {
         inds.forall(ind => isStatelessExpr(ind, context)) &&
         args.forall(arg => isStatelessExpr(arg, context)) &&
         isStatelessExpr(value, context)
+      case OperatorApplication(RecordUpdate(id, expr), args) =>
+        isStatelessExpr(expr, context) &&
+        args.forall(arg => isStatelessExpr(arg, context))
       case opapp : OperatorApplication =>
         opapp.operands.forall(arg => isStatelessExpr(arg, context + opapp.op))
       case a : ConstArray =>

--- a/src/main/scala/uclid/lang/PropertyRewriter.scala
+++ b/src/main/scala/uclid/lang/PropertyRewriter.scala
@@ -257,6 +257,8 @@ class LTLPropertyRewriterPass extends RewritePass {
           case ArrayUpdate(es, m) =>
             val esP = es.map(recurse(_))
             OperatorApplication(ArrayUpdate(esP, recurse(m)), args.map(recurse(_)))
+          case RecordUpdate(id, expr) =>
+            OperatorApplication(RecordUpdate(id, recurse(expr)), args.map(recurse(_)))
           case _ =>
             OperatorApplication(op, args.map(a => recurse(a)))
         }

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -106,6 +106,9 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
         inds.forall(ind => isStatelessExpr(ind, context)) &&
         args.forall(arg => isStatelessExpr(arg, context)) &&
         isStatelessExpr(value, context)
+      case OperatorApplication(RecordUpdate(id, expr), args) =>
+        isStatelessExpr(expr, context) &&
+        args.forall(a => isStatelessExpr(a, context))
       case OperatorApplication(FiniteForallOp(_, gId), _) =>
         val opapp = e.asInstanceOf[OperatorApplication]
         isStatelessExpr(gId, context) &&
@@ -171,6 +174,10 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
         val esP = es.map(e => rewrite(e, context))
         val valueP = rewrite(value, context)
         OperatorApplication(ArrayUpdate(indsP, valueP), esP)
+      case OperatorApplication(RecordUpdate(id, expr), es) =>
+        val esP = es.map(e => rewrite(e, context))
+        val exprP = rewrite(expr, context)
+        OperatorApplication(RecordUpdate(id, exprP), esP)
       case opapp : OperatorApplication =>
         val operandsP = opapp.operands.map(arg => rewrite(arg, context + opapp.op))
         OperatorApplication(opapp.op, operandsP)

--- a/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
+++ b/src/main/scala/uclid/lang/StatelessAxiomFinder.scala
@@ -121,6 +121,8 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
         opapp.operands.forall(arg => isStatelessExpr(arg, context + opapp.op))
       case a : ConstArray =>
         isStatelessExpr(a.exp, context)
+      case r : ConstRecord => 
+        r.fieldvalues.forall(f => isStatelessExpr(f._2, context))
       case fapp : FuncApplication =>
         isStatelessExpr(fapp.e, context) && fapp.args.forall(a => isStatelessExpr(a, context))
       case lambda : Lambda =>
@@ -184,6 +186,9 @@ class StatelessAxiomFinderPass(mainModuleName: Identifier)
       case a : ConstArray =>
         val eP = rewrite(a.exp, context)
         ConstArray(eP, a.typ)
+      case r : ConstRecord =>
+        val fsP = r.fieldvalues.map(f => (f._1, rewrite(f._2, context)))
+        ConstRecord(fsP)
       case fapp : FuncApplication =>
         val eP = rewrite(fapp.e, context)
         val argsP = fapp.args.map(rewrite(_, context))

--- a/src/main/scala/uclid/lang/StatementScheduler.scala
+++ b/src/main/scala/uclid/lang/StatementScheduler.scala
@@ -182,6 +182,7 @@ object StatementScheduler {
       case OperatorApplication(ArrayUpdate(inds, exp), exps) => readSets(inds, prime) ++ readSet(exp, prime) ++ readSets(exps, prime)
       case OperatorApplication(_, es) => readSets(es, prime)
       case ConstArray(e, _) => readSet(e, prime)
+      case ConstRecord(fs) => readSets(fs.map(a => a._2), prime)
       case FuncApplication(e, args) => readSet(e, prime) ++ readSets(args, prime)
       case Lambda(_, expr) => readSet(expr, prime)
     }

--- a/src/main/scala/uclid/lang/TaintPass.scala
+++ b/src/main/scala/uclid/lang/TaintPass.scala
@@ -67,6 +67,7 @@ class TaintNextPass extends RewritePass {
       case FreshLit(_) => None
       case IntLit(_) => None
       case ConstArray(_,_) => None
+      case ConstRecord(_) => None
       case StringLit(_) => None
       case Tuple(_) => None // Not handled
       case OperatorApplication(ArraySelect(_), _) |

--- a/src/main/scala/uclid/lang/TaintPass.scala
+++ b/src/main/scala/uclid/lang/TaintPass.scala
@@ -71,7 +71,9 @@ class TaintNextPass extends RewritePass {
       case Tuple(_) => None // Not handled
       case OperatorApplication(ArraySelect(_), _) |
            OperatorApplication(ArrayUpdate(_, _), _) =>
-             throw new Utils.UnimplementedException("TODO: Implement tainting for arrays.")
+            throw new Utils.UnimplementedException("TODO: Implement tainting for arrays.")
+      case OperatorApplication(RecordUpdate(_, _), _) =>
+            throw new Utils.UnimplementedException("TODO: Implement tainting for records.")
       case OperatorApplication(_, operands) => {
         val opers = operands.map(expr => generateTaintExpr(expr)).flatten
         if (opers.length > 1)

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -229,6 +229,8 @@ object ReplacePolymorphicOperators {
         OperatorApplication(opP, rs(operands))
       case ConstArray(exp, typ) =>
         ConstArray(r(exp), typ)
+      case ConstRecord(fs) => 
+        ConstRecord(fs.map(f => (f._1, r(f._2))))
       case FuncApplication(expr, args) =>
         FuncApplication(r(expr), rs(args))
       case Lambda(args, expr) =>
@@ -700,6 +702,10 @@ class ExpressionTypeCheckerPass extends ReadOnlyPass[Set[Utils.TypeError]]
               raiseTypeError("Expected an array type", a.typ.pos, c.filename)
               UndefinedType()
           }
+        case r : ConstRecord => 
+          val fieldnames = r.fieldvalues.map(f => f._1.name)
+          checkTypeError(fieldnames.size == fieldnames.toSet.size, "Duplicate field-names in ConstRecord", r.pos, c.filename)
+          new RecordType(r.fieldvalues.map(f => (f._1, typeOf(f._2, c))))
         case r : Tuple => new TupleType(r.values.map(typeOf(_, c)))
         case opapp : OperatorApplication => opAppType(opapp)
         case fapp : FuncApplication => funcAppType(fapp)

--- a/src/main/scala/uclid/lang/TypeChecker.scala
+++ b/src/main/scala/uclid/lang/TypeChecker.scala
@@ -594,12 +594,12 @@ class ExpressionTypeCheckerPass extends ReadOnlyPass[Set[Utils.TypeError]]
           arrayType
         case RecordUpdate(id, e) =>
           Utils.assert(argTypes.size == 1, "Expected only one argument to record update operator")
-          checkTypeError(argTypes(0).isRecord, "Expected an array here", opapp.operands(0).pos, c.filename)
+          checkTypeError(argTypes(0).isRecord, "Expected a record here", opapp.operands(0).pos, c.filename)
           val recordType = argTypes(0).asInstanceOf[lang.RecordType]
           val recordFieldTypes = recordType.fields
           checkTypeError(recordFieldTypes.map(a => a._1) contains id, "Invalid field-name in record update operator", id.pos, c.filename)
           val fieldType = recordFieldTypes.filter(a => (a._1.name == id.name))(0)._2
-          checkTypeError(typeOf(e, c) == fieldType, "Invalid field-type in record update operator", id.pos, c.filename)
+          checkTypeError(typeOf(e, c) == fieldType, "Invalid value-type in record update operator", id.pos, c.filename)
           recordType
         case SelectFromInstance(field) =>
           Utils.assert(argTypes.size == 1, "Select operator must have exactly one operand.")

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -551,6 +551,12 @@ case class ArrayUpdate(indices: List[Expr], value: Expr) extends Operator {
   }
   override def fixity = Operator.POSTFIX
 }
+case class RecordUpdate(fieldid: Identifier, value: Expr) extends Operator {
+  override def toString: String = {
+    "[" + fieldid.name + " := " + value.toString() + "]"
+  }
+  override def fixity: Int = Operator.POSTFIX
+}
 case class GetNextValueOp() extends Operator {
   override def toString = "'"
   override def fixity = Operator.POSTFIX

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -647,7 +647,13 @@ case class StringLit(value: String) extends Literal {
 }
 
 case class ConstArray(exp: Expr, typ: Type) extends Expr {
-  override def toString  = "const(%s, %s)".format(exp.toString(), typ.toString())
+  override def toString = "const(%s, %s)".format(exp.toString(), typ.toString())
+}
+
+case class ConstRecord(fieldvalues: List[(Identifier, Expr)]) extends Expr {
+  override def toString = "const_record(%s)".format(
+    fieldvalues.map(a => "%s := %s".format(a._1.toString, a._2.toString)).mkString(", ")
+  )
 }
 
 case class Tuple(values: List[Expr]) extends Expr {

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -204,7 +204,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
 // TODO_leiqi: add keywords for single double and half in here
 // finish!
     lexical.delimiters ++= List("(", ")", ",", "[", "]",
-      "bv", "fp", "{", "}", ";", "=", ":", "::", ".", "*", "::=", "->",
+      "bv", "fp", "{", "}", ";", "=", ":", "::", ".", "*", "::=", "->", ":=",
       OpAnd, OpOr, OpBvAnd, OpBvOr, OpBvXor, OpBvNot, OpAdd, OpSub, OpMul, OpDiv, OpUDiv,
       OpBiImpl, OpImpl, OpLT, OpGT, OpLE, OpGE, OpULT, OpUGT, OpULE, OpUGE, 
       OpEQ, OpNE, OpConcat, OpNot, OpMinus, OpPrime, OpBvUrem, OpBvSrem)
@@ -268,6 +268,9 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val ArrayStoreOp: Parser[ArrayUpdate] =
       ("[" ~> (Expr ~ rep("," ~> Expr) ~ ("->" ~> Expr)) <~ "]") ^^
       {case e ~ es ~ r => ArrayUpdate(e :: es, r)}
+    lazy val RecordStoreOp: Parser[RecordUpdate] =
+      ("[" ~> (Id ~ (":=" ~> Expr)) <~ "]") ^^ 
+      {case id ~ e => RecordUpdate(id, e)}
     lazy val ConstBitVectorSlice: Parser[lang.ConstBitVectorSlice] =
       positioned { ("[" ~> Integer ~ ":" ~ Integer <~ "]") ^^ { case x ~ ":" ~ y => lang.ConstBitVectorSlice(x.value.toInt, y.value.toInt) } }
     lazy val VarBitVectorSlice: Parser[lang.VarBitVectorSlice] =
@@ -403,7 +406,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     }
     /** ExpressionSuffixes. */
     lazy val ExprSuffix: PackratParser[Operator] = positioned {
-      ArraySelectOp | ArrayStoreOp | ExtractOp | RecordSelectOp | HyperSelectOp
+      ArraySelectOp | ArrayStoreOp | RecordStoreOp | ExtractOp | RecordSelectOp | HyperSelectOp
     }
     /** E12 = E12 (ExprList) | E12 ExprSuffix | E15 */
     lazy val E12: PackratParser[Expr] = positioned {

--- a/src/main/scala/uclid/lang/UclidParser.scala
+++ b/src/main/scala/uclid/lang/UclidParser.scala
@@ -150,6 +150,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
     lazy val KwVar = "var"
     lazy val KwSharedVar = "sharedvar"
     lazy val KwConst = "const"
+    lazy val KwConstRecord = "const_record"
     lazy val KwSkip = "skip"
     lazy val KwCall = "call"
     lazy val KwIf = "if"
@@ -214,7 +215,7 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
       "false", "true", "bv", "fp", KwProcedure, KwBoolean, KwInteger, KwHalf, KwSingle, KwDouble , KwReturns,
       KwAssume, KwAssert, KwSharedVar, KwVar, KwHavoc, KwCall, KwImport,
       KwIf, KwThen, KwElse, KwCase, KwEsac, KwFor, KwIn, KwRange, KwWhile,
-      KwInstance, KwInput, KwOutput, KwConst, KwModule, KwType, KwEnum,
+      KwInstance, KwInput, KwOutput, KwConst, KwConstRecord, KwModule, KwType, KwEnum,
       KwRecord, KwSkip, KwDefine, KwFunction, KwOracle, KwControl, KwInit,
       KwNext, KwLambda, KwModifies, KwProperty, KwDefineAxiom,
       KwForall, KwExists, KwFiniteForall, KwFiniteExists, KwGroup, KwDefault, KwSynthesis, KwGrammar, KwRequires,
@@ -420,14 +421,25 @@ object UclidParser extends UclidTokenParsers with PackratParsers {
         case (exp ~ typ) => lang.ConstArray(exp, typ)
       }
     }
-    /** E15 = false | true | Number | ConstArray | Id FuncApplication | (Expr) **/
+
+    lazy val RecordFieldAssign : PackratParser[(Identifier, Expr)] = {
+      Id ~ (":=" ~> Expr) ^^ { case id ~ e => (id, e) }
+    }
+    lazy val ConstRecord : PackratParser[lang.ConstRecord] = positioned {
+      KwConstRecord ~ "(" ~> RecordFieldAssign ~ rep("," ~> RecordFieldAssign) <~ ")" ^^ {
+        case a ~ as => lang.ConstRecord(a::as)
+      }
+    }
+
+    /** E15 = false | true | Number | ConstArray | ConstRecord | Id FuncApplication | (Expr) **/
     lazy val E15: PackratParser[Expr] = positioned {
         Literal |
         "{" ~> Expr ~ rep("," ~> Expr) <~ "}" ^^ {case e ~ es => Tuple(e::es)} |
         KwIf ~> ("(" ~> Expr <~ ")") ~ (KwThen ~> Expr) ~ (KwElse ~> Expr) ^^ {
           case expr ~ thenExpr ~ elseExpr => lang.OperatorApplication(lang.ITEOp(), List(expr, thenExpr, elseExpr))
         } |
-        ConstArray |
+        ConstArray | 
+        ConstRecord |
         KwLambda ~> (IdTypeList) ~ ("." ~> Expr) ^^ { case idtyps ~ expr => Lambda(idtyps, expr) } |
         "(" ~> Expr <~ ")" |
         Id <~ OpPrime ^^ { case id => lang.OperatorApplication(GetNextValueOp(), List(id)) } |

--- a/src/main/scala/uclid/smt/Context.scala
+++ b/src/main/scala/uclid/smt/Context.scala
@@ -271,6 +271,9 @@ object Context
           case Symbol(_, _) | IntLit(_) | FloatLit(_,_,_,_) | BitVectorLit(_, _) | BooleanLit(_) | BooleanLit(_) | EnumLit(_, _) | 
             ConstArray(_, _) | SynthSymbol (_, _, _, _, _) | OracleSymbol(_, _, _) =>
             rewrite(e)
+          case ConstRecord(fs) => 
+            val fsP = fs.map(f => (f._1, rewriteExpr(f._2, rewrite, memo)))
+            rewrite(ConstRecord(fsP))
           case OperatorApplication(op, operands) =>
             val operandsP = operands.map(arg => rewriteExpr(arg, rewrite, memo))
             rewrite(OperatorApplication(op, operandsP))
@@ -335,6 +338,8 @@ object Context
             eResult
           case ConstArray(expr, _) =>
             eResult ++ accumulateOverExpr(expr, apply, memo)
+          case ConstRecord(fs) => 
+            eResult ++ accumulateOverExprs(fs.map(f => f._2), apply, memo)
           case OperatorApplication(_,operands) =>
             eResult ++ accumulateOverExprs(operands, apply, memo)
           case ArraySelectOperation(e, index) =>

--- a/src/main/scala/uclid/smt/Converter.scala
+++ b/src/main/scala/uclid/smt/Converter.scala
@@ -266,6 +266,8 @@ object Converter {
         smt.FloatLit(i,f,e,s)
       case lang.ConstArray(value, arrTyp) =>
         smt.ConstArray(toSMT(value, scope, past), typeToSMT(arrTyp).asInstanceOf[ArrayType])
+      case lang.ConstRecord(fs) => 
+        smt.ConstRecord(fs.map(f => (f._1.toString, toSMT(f._2, scope, past))))
       case lang.StringLit(_) => throw new Utils.RuntimeError("Strings are not supported in smt.Converter")
       case lang.Tuple(args) => smt.MakeTuple(toSMTs(args, scope, past))
       case opapp : lang.OperatorApplication =>

--- a/src/main/scala/uclid/smt/SExprParser.scala
+++ b/src/main/scala/uclid/smt/SExprParser.scala
@@ -250,8 +250,6 @@ object SExprParser extends SExprTokenParsers with PackratParsers {
   lazy val KwPar = "par"
   lazy val KwDefFun = "define-fun"
 
-  lazy val KwUpdateField = "update-field" // for record update, not in SMTLIB, but used by solvers
-
   // Need to add to deal with Z3 output
   lazy val KwDecFun = "declare-fun"
   

--- a/src/main/scala/uclid/smt/SExprParser.scala
+++ b/src/main/scala/uclid/smt/SExprParser.scala
@@ -250,6 +250,8 @@ object SExprParser extends SExprTokenParsers with PackratParsers {
   lazy val KwPar = "par"
   lazy val KwDefFun = "define-fun"
 
+  lazy val KwUpdateField = "update-field" // not in SMTLIB, but used by solvers
+
   // Need to add to deal with Z3 output
   lazy val KwDecFun = "declare-fun"
   

--- a/src/main/scala/uclid/smt/SExprParser.scala
+++ b/src/main/scala/uclid/smt/SExprParser.scala
@@ -250,7 +250,7 @@ object SExprParser extends SExprTokenParsers with PackratParsers {
   lazy val KwPar = "par"
   lazy val KwDefFun = "define-fun"
 
-  lazy val KwUpdateField = "update-field" // not in SMTLIB, but used by solvers
+  lazy val KwUpdateField = "update-field" // for record update, not in SMTLIB, but used by solvers
 
   // Need to add to deal with Z3 output
   lazy val KwDecFun = "declare-fun"

--- a/src/main/scala/uclid/smt/SMTLIB2Interface.scala
+++ b/src/main/scala/uclid/smt/SMTLIB2Interface.scala
@@ -223,6 +223,18 @@ trait SMTLIB2Base {
             assert (newTypes.size == 0)
             val str = "((as const %s) %s)".format(typName, eP.exprString())
             (str, memoP, shouldLetify)
+          case r : ConstRecord =>
+            val productType = r.typ.asInstanceOf[ProductType]
+            val typeName = typeMap.get(r.typ).get.name
+            val mkTupleFn = Context.getMkTupleFunction(typeName)
+            val indexedFields = r.fieldvalues.map(f => (productType.fieldIndex(f._1), f._2)).sortBy(_._1)
+            var memoP = memo
+            val fields = indexedFields.map{ f =>
+              val (value, memoP1) = translateExpr(f._2, memoP, shouldLetify)
+              memoP = memoP1
+              value.exprString()
+            }.mkString(" ")
+            ("(" + mkTupleFn + " " + fields + ")", memoP, shouldLetify)
           case OperatorApplication(RecordUpdateOp(fld), operands) =>
             val productType = operands(0).typ.asInstanceOf[ProductType]
             val typeName = typeMap.get(operands(0).typ).get.name

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -845,6 +845,13 @@ case class ConstArray(expr : Expr, arrTyp: ArrayType) extends Expr (arrTyp) {
   override val md5hashCode = computeMD5Hash(expr, arrTyp)
   override def toString = "(const %s %s)".format(expr.toString, arrTyp.toString)
 }
+case class ConstRecord(fieldvalues : List[(String, Expr)]) extends Expr (RecordType(fieldvalues.map(a => (a._1, a._2.typ)))) {
+  override val hashId: Int = 316
+  override val hashCode = computeHash(fieldvalues)
+  override val md5hashCode: Array[Byte] = computeMD5Hash(fieldvalues)
+  override def toString = "const-record [" + Utils.join(fieldvalues.map(f => f._1 + " := " + f._2.toString), ", ") + "]"
+  override val isConstant: Boolean = fieldvalues.forall(p => p._2.isConstant)
+}
 // Tuple creation.
 case class MakeTuple(args: List[Expr]) extends Expr (TupleType(args.map(_.typ))) {
   override val hashId = 306

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -696,19 +696,6 @@ case class Int2BVOp(w : Int) extends BVResultOp(w) {
   }
 }
 
-/*
-  This is provided in addition to RecordUpdateOp to support 
-  Uclid record update expression. 
-  This also specifies the new field value to update the record with.
-*/
-// case class RecordUpdateOperation(e : Expr, fieldid: String, value: Expr) extends Expr(e.typ) {
-//   override val hashId = mix(fieldid.hashCode(), 246)
-//   override val hashCode = computeHash(fieldid, e, value)
-//   override val md5hashCode: Array[Byte] = computeMD5Hash(e, fieldid, value)
-//   override def toString = e.toString + "[" + fieldid + " := " + value.toString + "]"
-//   override val isConstant = e.isConstant && value.isConstant
-// }
-
 // Floating point operators
 // Operators that return bitvectors.
 abstract class FloatResultOp(e: Int, s : Int) extends Operator {

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -696,6 +696,19 @@ case class Int2BVOp(w : Int) extends BVResultOp(w) {
   }
 }
 
+/*
+  This is provided in addition to RecordUpdateOp to support 
+  Uclid record update expression. 
+  This also specifies the new field value to update the record with.
+*/
+// case class RecordUpdateOperation(e : Expr, fieldid: String, value: Expr) extends Expr(e.typ) {
+//   override val hashId = mix(fieldid.hashCode(), 246)
+//   override val hashCode = computeHash(fieldid, e, value)
+//   override val md5hashCode: Array[Byte] = computeMD5Hash(e, fieldid, value)
+//   override def toString = e.toString + "[" + fieldid + " := " + value.toString + "]"
+//   override val isConstant = e.isConstant && value.isConstant
+// }
+
 // Floating point operators
 // Operators that return bitvectors.
 abstract class FloatResultOp(e: Int, s : Int) extends Operator {

--- a/src/main/scala/uclid/smt/Z3Interface.scala
+++ b/src/main/scala/uclid/smt/Z3Interface.scala
@@ -531,6 +531,9 @@ class Z3Interface() extends Context {
       case BooleanLit(b) => getBoolLit(b)
       case EnumLit(e, typ) => getEnumLit(e, typ)
       case ConstArray(expr, typ) => getConstArray(expr, typ)
+      case r : ConstRecord => 
+        val prodSort = getProductSort(r.typ.asInstanceOf[ProductType])
+        prodSort.mkDecl().apply(typecastAST[z3.Expr](r.fieldvalues.map(f => exprToZ3(f._2))).toSeq : _*)
       case MakeTuple(args) =>
         val tupleSort = getTupleSort(args.map(_.typ))
         tupleSort.mkDecl().apply(typecastAST[z3.Expr](args.map(exprToZ3(_))).toSeq : _*)

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -672,6 +672,39 @@ class ParserSpec extends AnyFlatSpec {
     assert (instantiatedModules.size == 1)
   }
 
+  "test-const-record-1.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-record-1.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-const-record-2.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-record-2.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+        case p : Utils.ParserErrorList =>
+          assert (p.errors.size == 1)
+          assert (p.errors(0)._1.contains("expected type 'record {valid : boolean, value : integer}' but received type 'record {value : integer, valid : boolean}'"))
+        case _ : Throwable => assert(false);
+    }
+  }
+  "test-const-record-4.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-record-4.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-const-record-5.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-const-record-5.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+        assert (p.errors(0).getMessage().contains("Duplicate field-names in ConstRecord"))
+      case _ : Throwable => assert(false);
+    }
+  }
+
   "recorderror.ucl" should "parse successfully." in {
     val fileModules = UclidMain.compile(ConfigCons.createConfig("test/recorderror.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -623,6 +623,55 @@ class ParserSpec extends AnyFlatSpec {
     assert (instantiatedModules.size == 1)
   }
 
+  "test-record-update-op-1.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-1.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-record-update-op-2.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-2.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+        assert (p.errors(0).getMessage().contains("Invalid field-name in record update operator"))
+      case _ : Throwable => assert(false);
+    }
+  }
+  "test-record-update-op-3.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-3.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+        assert (p.errors(0).getMessage().contains("Expected a record here"))
+      case _ : Throwable => assert(false);
+    }
+  }
+  "test-record-update-op-4.ucl" should "not parse successfully." in {
+    try {
+      val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-4.ucl"), lang.Identifier("main"))
+      assert (false)
+    } catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+        assert (p.errors(0).getMessage().contains("Invalid value-type in record update operator"))
+      case _ : Throwable => assert(false);
+    }
+  }
+  "test-record-update-op-5.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-5.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+  "test-record-update-op-8.ucl" should "parse successfully." in {
+    val fileModules = UclidMain.compile(ConfigCons.createConfig("test/test-record-update-op-8.ucl"), lang.Identifier("main"))
+    val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))
+    assert (instantiatedModules.size == 1)
+  }
+
   "recorderror.ucl" should "parse successfully." in {
     val fileModules = UclidMain.compile(ConfigCons.createConfig("test/recorderror.ucl"), lang.Identifier("main"))
     val instantiatedModules = UclidMain.instantiateModules(UclidMain.Config(), fileModules, lang.Identifier("main"))

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -174,6 +174,22 @@ class BasicVerifierSpec extends AnyFlatSpec {
   "test-record-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-record-1.ucl", 0)
   }
+  "test-record-update-op-1.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-1.ucl", 1)
+  }
+  "test-record-update-op-5.ucl" should "fail to verify 2 assertions." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-5.ucl", 2)
+  }
+  "test-record-update-op-6.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-6.ucl", 0)
+  }
+  "test-record-update-op-7.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-7.ucl", 1)
+  }
+  "test-record-update-op-8.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-8.ucl", 1)
+  }
+
   "test-tuple-record-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-tuple-record-1.ucl", 0)
   }
@@ -381,6 +397,10 @@ class InductionVerifSpec extends AnyFlatSpec {
   "test-tuple.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-tuple.ucl", 0)
   }
+  "test-record-update-op-9.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-record-update-op-9.ucl", 0)
+  }
+
 }
 class QuantifierVerifSpec extends AnyFlatSpec {
   "test-forall-0.ucl" should "verify all assertions." in {

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -190,6 +190,16 @@ class BasicVerifierSpec extends AnyFlatSpec {
     VerifierSpec.expectedFails("./test/test-record-update-op-8.ucl", 1)
   }
 
+  "test-const-record-1.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-const-record-1.ucl", 1)
+  }
+  "test-const-record-4.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-const-record-4.ucl", 0)
+  }
+  "test-const-record-6.ucl" should "fail to verify 1 assertion." in {
+    VerifierSpec.expectedFails("./test/test-const-record-6.ucl", 1)
+  }
+
   "test-tuple-record-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-tuple-record-1.ucl", 0)
   }
@@ -399,6 +409,12 @@ class InductionVerifSpec extends AnyFlatSpec {
   }
   "test-record-update-op-9.ucl" should "verify all assertions." in {
     VerifierSpec.expectedFails("./test/test-record-update-op-9.ucl", 0)
+  }
+  "test-const-record-3.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-const-record-3.ucl", 0)
+  }
+  "test-const-record-7.ucl" should "verify all assertions." in {
+    VerifierSpec.expectedFails("./test/test-const-record-7.ucl", 0)
   }
 
 }

--- a/test/test-const-record-1.ucl
+++ b/test/test-const-record-1.ucl
@@ -1,0 +1,21 @@
+module main {
+
+    var cache : record {valid : boolean, value : integer};
+
+    init {
+        cache = const_record(valid := true, value := 100);
+    }
+
+    next {
+        havoc cache;
+    }
+
+    invariant trivial : cache.valid;
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(cache);
+    }
+}

--- a/test/test-const-record-2.ucl
+++ b/test/test-const-record-2.ucl
@@ -1,0 +1,21 @@
+module main {
+
+    var cache : record {valid : boolean, value : integer};
+
+    init {
+        cache = const_record(value := 100, valid := true);
+    }
+
+    next {
+        havoc cache;
+    }
+
+    invariant trivial : cache.valid;
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(cache);
+    }
+}

--- a/test/test-const-record-3.ucl
+++ b/test/test-const-record-3.ucl
@@ -1,0 +1,39 @@
+module main {
+
+    type cacheline_t    = record { valid : boolean, value : bv32 };
+    type cache_t        = record { numlines : integer, lines : [bv4]cacheline_t };
+
+    var cacheline   : cacheline_t;
+    var lineblock   : [bv4]cacheline_t;
+    var cache       : cache_t;
+    var lineaddr    : bv4;
+
+    init {
+        cacheline.valid = true;
+        assume(forall (a : bv4) :: lineblock[a] == cacheline);
+        cache = const_record(numlines := 100, lines := lineblock);
+    }
+
+    procedure write_line ()
+        modifies cache, lineblock;
+    {
+        assume(cacheline.valid);
+        lineblock[lineaddr] = cacheline;
+        cache.lines = lineblock;
+    }
+
+    next {
+        havoc cacheline;
+        havoc lineaddr;
+        call () = write_line();
+    }
+
+    invariant trivial : forall (a : bv4) :: cache.lines[a].valid;
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(cache);
+    }
+}

--- a/test/test-const-record-4.ucl
+++ b/test/test-const-record-4.ucl
@@ -1,0 +1,19 @@
+module main {
+
+    var sbool : boolean;
+
+    init {
+        if (const_record(valid := true, value := 10).valid) {
+            sbool = true;
+        }
+    }
+
+    invariant trivial : sbool;
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(sbool);
+    }
+}

--- a/test/test-const-record-5.ucl
+++ b/test/test-const-record-5.ucl
@@ -1,0 +1,19 @@
+module main {
+
+    var sbool : boolean;
+
+    init {
+        if (const_record(valid := true, valid := 10).valid) {
+            sbool = true;
+        }
+    }
+
+    invariant trivial : sbool;
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(sbool);
+    }
+}

--- a/test/test-const-record-6.ucl
+++ b/test/test-const-record-6.ucl
@@ -1,0 +1,22 @@
+module main {
+
+    var cache : record {valid : boolean, value : [bv4]bv32};
+    var cache_store : [bv4]bv32;
+
+    init {
+        cache = const_record(valid := true, value := cache_store);
+    }
+
+    next {
+        havoc cache_store;
+    }
+
+    invariant trivial : cache.value[0bv4] == cache_store[0bv4];
+
+    control {
+        v = bmc(1);
+        check;
+        print_results;
+        v.print_cex(cache);
+    }
+}

--- a/test/test-const-record-7.ucl
+++ b/test/test-const-record-7.ucl
@@ -1,0 +1,23 @@
+module main {
+
+    var cache : record {valid : boolean, value : [bv4]bv32};
+    var cache_store : [bv4]bv32;
+
+    init {
+        cache = const_record(valid := true, value := cache_store);
+    }
+
+    next {
+        havoc cache_store;
+        cache' = const_record(valid := true, value := cache_store');
+    }
+
+    invariant trivial : cache.value[0bv4] == cache_store[0bv4];
+
+    control {
+        v = induction;
+        check;
+        print_results;
+        v.print_cex(cache);
+    }
+}

--- a/test/test-record-update-op-1.ucl
+++ b/test/test-record-update-op-1.ucl
@@ -22,6 +22,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-1.ucl
+++ b/test/test-record-update-op-1.ucl
@@ -1,0 +1,27 @@
+module main {
+
+    type cache_t = record { valid : boolean, value : integer };
+
+    var cache   : cache_t;
+    var cache1  : cache_t;
+
+    init {
+        cache.valid = true;
+        cache.value = 10;
+        cache1 = cache[value := 1998];
+    }
+
+    next {
+        havoc cache1;
+    }
+
+    invariant trivial1  : cache1.value == 1998;
+
+    control {
+        v = bmc(2);
+        check;
+        print_results;
+        v.print_cex_json(cache);
+        print_module();
+    }
+}

--- a/test/test-record-update-op-2.ucl
+++ b/test/test-record-update-op-2.ucl
@@ -22,6 +22,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-2.ucl
+++ b/test/test-record-update-op-2.ucl
@@ -8,7 +8,7 @@ module main {
     init {
         cache.valid = true;
         cache.value = 10;
-        cache1 = cache[value := 2022];
+        cache1 = cache[badfield := 2022];
     }
 
     next {

--- a/test/test-record-update-op-3.ucl
+++ b/test/test-record-update-op-3.ucl
@@ -2,13 +2,11 @@ module main {
 
     type cache_t = record { valid : boolean, value : integer };
 
-    var cache   : cache_t;
-    var cache1  : cache_t;
+    var notarecord  : [bv4]bv4;
+    var cache1      : cache_t;
 
     init {
-        cache.valid = true;
-        cache.value = 10;
-        cache1 = cache[value := 2022];
+        cache1 = notarecord[badfield := 2022];
     }
 
     next {

--- a/test/test-record-update-op-3.ucl
+++ b/test/test-record-update-op-3.ucl
@@ -20,6 +20,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-4.ucl
+++ b/test/test-record-update-op-4.ucl
@@ -6,9 +6,7 @@ module main {
     var cache1  : cache_t;
 
     init {
-        cache.valid = true;
-        cache.value = 10;
-        cache1 = cache[value := 2022];
+        cache1 = cache[value := 0xDEADBEEFbv32];
     }
 
     next {

--- a/test/test-record-update-op-4.ucl
+++ b/test/test-record-update-op-4.ucl
@@ -20,6 +20,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-5.ucl
+++ b/test/test-record-update-op-5.ucl
@@ -1,21 +1,21 @@
 module main {
 
-    type cache_t = record { valid : boolean, value : integer };
+    type cache_t = record { valid : boolean, value : [bv4]bv32 };
 
     var cache   : cache_t;
     var cache1  : cache_t;
 
+    var cache_entry : [bv4]bv32;
+
     init {
-        cache.valid = true;
-        cache.value = 10;
-        cache1 = cache[value := 2022];
+        cache1 = cache[value := cache_entry];
     }
 
     next {
         havoc cache1;
     }
 
-    invariant trivial1  : cache1.value == 2022;
+    invariant trivial1  : cache1.value[0bv4] == 2022bv32;
 
     control {
         v = bmc(1);

--- a/test/test-record-update-op-5.ucl
+++ b/test/test-record-update-op-5.ucl
@@ -22,6 +22,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-6.ucl
+++ b/test/test-record-update-op-6.ucl
@@ -6,16 +6,14 @@ module main {
     var cache1  : cache_t;
 
     init {
-        cache.valid = true;
-        cache.value = 10;
         cache1 = cache[value := 2022];
     }
 
     next {
-        havoc cache1;
+        cache1' = cache[value := 42];
     }
 
-    invariant trivial1  : cache1.value == 2022;
+    invariant trivial1  : cache1.value == 2022 || cache1.value == 42;
 
     control {
         v = bmc(1);

--- a/test/test-record-update-op-6.ucl
+++ b/test/test-record-update-op-6.ucl
@@ -20,6 +20,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-7.ucl
+++ b/test/test-record-update-op-7.ucl
@@ -1,21 +1,22 @@
 module main {
 
-    type cache_t = record { valid : boolean, value : integer };
+    type cache_t = record { valid : boolean, value : [bv4]bv32 };
 
     var cache   : cache_t;
     var cache1  : cache_t;
 
+    var cache_entry : [bv4]bv32;
+
     init {
-        cache.valid = true;
-        cache.value = 10;
-        cache1 = cache[value := 2022];
+        cache_entry[0bv4] = 2022bv32;
+        cache1 = cache[value := cache_entry];
     }
 
     next {
         havoc cache1;
     }
 
-    invariant trivial1  : cache1.value == 2022;
+    invariant trivial1  : cache1.value[0bv4] == 2022bv32;
 
     control {
         v = bmc(1);

--- a/test/test-record-update-op-7.ucl
+++ b/test/test-record-update-op-7.ucl
@@ -23,6 +23,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-8.ucl
+++ b/test/test-record-update-op-8.ucl
@@ -26,6 +26,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-8.ucl
+++ b/test/test-record-update-op-8.ucl
@@ -6,19 +6,23 @@ module main {
     var cache1  : cache_t;
 
     init {
-        cache.valid = true;
-        cache.value = 10;
         cache1 = cache[value := 2022];
     }
 
-    next {
-        havoc cache1;
+    procedure write_to_cache1 ()
+        modifies cache1;
+    {
+        cache1 = cache1[value := (cache1.value+1)];
     }
 
-    invariant trivial1  : cache1.value == 2022;
+    next {
+        call () = write_to_cache1();
+    }
+
+    invariant trivial1  : cache1.value < 2024;
 
     control {
-        v = bmc(1);
+        v = bmc(2);
         check;
         print_results;
         v.print_cex_json(cache1);

--- a/test/test-record-update-op-9.ucl
+++ b/test/test-record-update-op-9.ucl
@@ -28,6 +28,5 @@ module main {
         check;
         print_results;
         v.print_cex_json(cache1);
-        print_module();
     }
 }

--- a/test/test-record-update-op-9.ucl
+++ b/test/test-record-update-op-9.ucl
@@ -1,0 +1,33 @@
+module main {
+
+    type cache_t = record { valid : boolean, value : integer };
+
+    var cache   : cache_t;
+    var cache1  : cache_t;
+
+    init {
+        cache.value = 2021;
+        cache1 = cache[value := (cache.value+1)];
+    }
+
+    procedure write_to_cache1 ()
+        modifies cache, cache1;
+    {
+        cache   = cache[value := (cache.value+1)];
+        cache1  = cache1[value := (cache1.value+1)];
+    }
+
+    next {
+        call () = write_to_cache1();
+    }
+
+    invariant trivial1  : cache1.value == (cache.value + 1);
+
+    control {
+        v = induction();
+        check;
+        print_results;
+        v.print_cex_json(cache1);
+        print_module();
+    }
+}


### PR DESCRIPTION
Two UclidLang features:

1. Record updates: syntax recordname[fieldname := newvalueexpr]
2. Constant records (similar to constant arrays): syntax const_record( rep(fieldname := valueexpr) )
      - fields are ordered; const_record(valid := true, value := 100) and const_record(value := 100, valid := true) have different types
      - fieldnames must be distinct

Note: this is a records-changes-only version of PR #162 

TODO: Use this to improve SExpr parsing