### PR TITLE
Fix up on sexper's tests

### DIFF
--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -755,7 +755,7 @@ class PrintCexSpec extends AnyFlatSpec {
       case JString(s) => assert(s.contains("update-field _field_value"))
       case _ => assert(false)
     }
-    val str1 = ((json \ "property__trivial__0" \ "trace")(1) \ "cache1")(0)
+    val str1 = ((json \ "property__trivial__1" \ "trace")(1) \ "cache1")(0)
     str1 match {
       case JString(s) => assert(s.equals("const_record(valid := false, value := 0)"))
       case _ => assert(false)

--- a/test/test-sexpr-uclid-lang-mixed-1.ucl
+++ b/test/test-sexpr-uclid-lang-mixed-1.ucl
@@ -7,6 +7,7 @@ module main {
 
     init {
         assume(database[0] == database[1]);
+        assume(database[0].uid == 2);
     }
 
     invariant trivial : database[0] == database[2];

--- a/test/test-sexpr-uclid-lang-mixed-3.ucl
+++ b/test/test-sexpr-uclid-lang-mixed-3.ucl
@@ -8,6 +8,7 @@ module main {
 
     init {
         assume(database[0] == database[1]);
+        assume(database[0].uid == 2);
     }
 
     invariant trivial : database[0] == database[2];

--- a/test/test-sexpr-uclid-lang-records-1.ucl
+++ b/test/test-sexpr-uclid-lang-records-1.ucl
@@ -15,7 +15,7 @@ module main {
         havoc cache1;
     }
 
-    invariant trivial  : cache1.value == 2022;
+    invariant trivial  : cache1.value == 2022 && cache1.value < 2;
 
     control {
         v = bmc(1);


### PR DESCRIPTION
Problem:
In the tests on sexper, some examples will give different counterexamples due to different versions of SMT-solver.
And this pull request is going to limit that test to only one possible counter-example to avoid this situation.

There is a list of tests, which have been changed.

test-sexpr-uclid-lang-mixed-3.ucl
test-sexpr-uclid-lang-mixed-1.ucl
test-sexpr-uclid-lang-records-1.ucl
