### PR TITLE
Fix a wrong condition in old-instance-var test

### DIFF
--- a/test/test-old-instance-var-0.ucl
+++ b/test/test-old-instance-var-0.ucl
@@ -54,7 +54,7 @@ module main {
   }
 
   procedure [noinline] update_a()
-    ensures(a == a+1);
+    ensures(a == old(a)+1);
     ensures(b == old(b));
     modifies a;
     modifies b;


### PR DESCRIPTION
Before the fix, calling `update_a()` makes all the following assert statements as `PASSED` even if it is a false one.