### PR TITLE
update sleep useage

### DIFF
--- a/cvc5_wait.sh
+++ b/cvc5_wait.sh
@@ -1,2 +1,2 @@
-sleep 1s
+sleep 1
 cvc5 --lang sygus --force-logic=ALL "$@"


### PR DESCRIPTION
fix script for the CI. This script forces cvc5 to wait long enough to prevent the interactive process from failing on the fast synthesis queries. Not sure what caused this script to start failing