### PR TITLE
Fix issue with SExpr parser

### DIFF
--- a/src/main/scala/uclid/AssertionTree.scala
+++ b/src/main/scala/uclid/AssertionTree.scala
@@ -39,7 +39,7 @@
 
 package uclid
 
-import uclid.lang._
+import lang._
 import com.typesafe.scalalogging.Logger
 import scala.collection.mutable.ListBuffer
 

--- a/src/main/scala/uclid/SymbolicSimulator.scala
+++ b/src/main/scala/uclid/SymbolicSimulator.scala
@@ -48,7 +48,7 @@ import vcd.VCD
 import scala.util.Try
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import com.typesafe.scalalogging.Logger
-import uclid.smt.Z3Interface
+import smt.Z3Interface
 
 import scala.collection.mutable.{Map => MutableMap}
 import org.scalactic.source.Position
@@ -58,8 +58,8 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import scala.collection.mutable
-import uclid.smt.SMTLIB2Interface
-import uclid.smt.Context
+import smt.SMTLIB2Interface
+import smt.Context
 
 object UniqueIdGenerator {
   var i : Int = 0;

--- a/src/main/scala/uclid/UclidMain.scala
+++ b/src/main/scala/uclid/UclidMain.scala
@@ -45,7 +45,7 @@ package uclid
 import scala.util.parsing.combinator._
 import scala.collection.immutable._
 import lang.{Identifier, Module,  _}
-import uclid.Utils.ParserErrorList
+import Utils.ParserErrorList
 import com.typesafe.scalalogging.Logger
 
 /** This is the main class for Uclid.

--- a/src/main/scala/uclid/lang/BitvectorSliceRewriter.scala
+++ b/src/main/scala/uclid/lang/BitvectorSliceRewriter.scala
@@ -57,8 +57,8 @@
 package uclid
 package lang
 
-import uclid.smt.{Converter => Converter}
-import uclid.smt.{ExpressionAnalyzer => ExpressionAnalyzer}
+import smt.{Converter => Converter}
+import smt.{ExpressionAnalyzer => ExpressionAnalyzer}
 
 class BitVectorSliceFindWidthPass extends RewritePass {
   def rewriteSlice(slice : VarBitVectorSlice, ctx : Scope) : VarBitVectorSlice = {

--- a/src/main/scala/uclid/lang/PrimedAssignmentChecker.scala
+++ b/src/main/scala/uclid/lang/PrimedAssignmentChecker.scala
@@ -39,7 +39,7 @@
 package uclid
 package lang
 
-import uclid.lang.Scope.BlockVar
+import lang.Scope.BlockVar
 
 class PrimedAssignmentCheckerPass extends ReadOnlyPass[Set[ModuleError]]
 {

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -45,8 +45,8 @@ import scala.collection.mutable.{Map => MutableMap}
 import scala.util.parsing.input.Positional
 import scala.util.parsing.input.Position
 import scala.reflect.ClassTag
-import uclid.smt.SynonymMap
-import uclid.smt.Converter
+import smt.SynonymMap
+import smt.Converter
 
 object PrettyPrinter
 {

--- a/src/main/scala/uclid/smt/SExprParser.scala
+++ b/src/main/scala/uclid/smt/SExprParser.scala
@@ -559,7 +559,11 @@ object SExprParser extends SExprTokenParsers with PackratParsers {
   lazy val UclidIdentifier : PackratParser[(lang.UIdentifier, String)] =
     UclidSymbol |
     "(" ~ KwUS ~> UclidSymbol ~ rep1(UclidSymbol|UclidIntegerLit) <~ ")" ^^ { case sym ~ idxs =>
-      (lang.IndexedIdentifier(sym._1.toString, idxs.map(a => a._1.asInstanceOf[Either[lang.IntLit, lang.Identifier]])),
+      (lang.IndexedIdentifier(sym._1.toString, idxs.map(a => a._1 match {
+        case s : lang.Identifier => Right(s)
+        case i : lang.IntLit => Left(i)
+        case _ => throw new Utils.RuntimeError("UclidIdentifier has unsupported type!")
+      })),
         joinWithSpace(KwUS, sym._2, idxs.map(a => a._2).mkString(" ")))
     }
 

--- a/src/main/scala/uclid/smt/SMTLIB2Interface.scala
+++ b/src/main/scala/uclid/smt/SMTLIB2Interface.scala
@@ -44,11 +44,11 @@ import scala.collection.mutable.{Map => MutableMap}
 import scala.collection.mutable.{Set => MutableSet}
 import scala.collection.mutable.ListBuffer
 import com.typesafe.scalalogging.Logger
-import uclid.lang.Identifier
+import lang.Identifier
 
 import org.json4s._
-import _root_.uclid.lang.Scope
-import _root_.uclid.lang.ExpressionEnvironment
+import lang.Scope
+import lang.ExpressionEnvironment
 
 trait SMTLIB2Base {
   val smtlib2BaseLogger = Logger(classOf[SMTLIB2Base])

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -39,7 +39,7 @@
 package uclid
 package smt
 import scala.util.matching.Regex
-import uclid.lang.Identifier
+import lang.Identifier
 
 sealed trait Type extends Hashable {
   override val hashBaseId = 22575 // Random number. Not super important, must just be unique for each abstract base class.


### PR DESCRIPTION
- Fixes fragile construction of `Either` type for `IndexedIdentifier`s in the SExprParser. Indexed identifiers are seen in bit-vector declarations (e.g., `(_ BitVec 32)`)
- Also, removes redundant prefixes in import statements.