### PR TITLE
Adding support for Algebraic Datatypes

### DIFF
--- a/src/main/scala/uclid/lang/RewriteRecordSelect.scala
+++ b/src/main/scala/uclid/lang/RewriteRecordSelect.scala
@@ -20,6 +20,20 @@ class RewriteRecordSelectPass extends RewritePass {
     }
   }
 
+  override def rewriteDataType(dataT : DataType, context : Scope) : Option[DataType] = { 
+    Some(DataType(dataT.id, dataT.constructors.map(c => (c._1, c._2.map(s => {
+      if(!hasRecPrefix(s))
+      {
+        (Identifier(recordPrefix+s._1.toString), s._2)
+      }
+      else
+      {
+        UclidMain.printDebugRewriteRecord("we have not rewritten this selector " + dataT.toString )
+        s
+      }
+    })))))
+  }
+
 }
 
 class RewriteRecordSelect extends ASTRewriter(

--- a/src/main/scala/uclid/lang/SemanticAnalyzer.scala
+++ b/src/main/scala/uclid/lang/SemanticAnalyzer.scala
@@ -88,7 +88,27 @@ class SemanticAnalyzerPass extends ReadOnlyPass[List[ModuleError]] {
     if (d == TraversalDirection.Down) {
       // val moduleIds = module.decls.filter((d) => d.declNames.isDefined).map((d) => (d.declName.get, d.position))
       val moduleIds = module.decls.flatMap((d) => d.declNames.map((n) => (n, d.position)))
-      SemanticAnalyzerPass.checkIdRedeclaration(moduleIds, in)
+      val selectorIds = module.decls.flatMap((d) => {
+        d match {
+          case TypeDecl(id, typ) => typ match {
+            case DataType(id, constructors) => constructors.flatMap((c) => c._2.map(s => (s._1, s._1.position)))
+            case _ => List()
+          }
+          case _ => List()
+        }
+      })
+      val constructorIds = module.decls.flatMap((d) => {
+        d match {
+          case TypeDecl(id, typ) => typ match {
+            case DataType(id, constructors) => constructors.map((c) => (c._1, c._1.position))
+            case _ => List()
+          }
+          case _ => List()
+        }
+      })
+      SemanticAnalyzerPass.checkIdRedeclaration(moduleIds, in) ++
+      SemanticAnalyzerPass.checkIdRedeclaration(selectorIds, in) ++
+      SemanticAnalyzerPass.checkIdRedeclaration(constructorIds, in)
     } else { in }
   }
   override def applyOnProcedure(d : TraversalDirection.T, proc : ProcedureDecl, in : List[ModuleError], context : Scope) : List[ModuleError] = {
@@ -118,6 +138,18 @@ class SemanticAnalyzerPass extends ReadOnlyPass[List[ModuleError]] {
       in
     }
   }
+
+  override def applyOnDataType(d : TraversalDirection.T, dataT : DataType, in : List[ModuleError], context : Scope) : List[ModuleError] = {
+    if (d == TraversalDirection.Down) {
+      val cstor_ids = dataT.constructors.map(x => (x._1, x._1.position)).toSeq
+      val selector_ids = dataT.constructors.flatMap(x => x._2.map(y => (y._1, y._1.position))).toSeq
+      SemanticAnalyzerPass.checkIdRedeclaration(cstor_ids, in)
+      SemanticAnalyzerPass.checkIdRedeclaration(selector_ids, in)
+    } else {
+      in
+    }
+  }
+
   override def applyOnInstance(d : TraversalDirection.T, inst : InstanceDecl, in : List[ModuleError], context : Scope) : List[ModuleError] = {
     if (d == TraversalDirection.Down) {
 //      val modType = inst.modType.get

--- a/src/main/scala/uclid/lang/UclidLanguage.scala
+++ b/src/main/scala/uclid/lang/UclidLanguage.scala
@@ -1201,6 +1201,25 @@ case class MapType(inTypes: List[Type], outType: Type) extends Type {
   override def isMap = true
 }
 
+case class DataType(id : Identifier, constructors: List[(Identifier, List[(Identifier, Type)])]) extends Type {
+  override def toString = {
+    id.name + " = | " + constructors.map(c => c.toString()).mkString(" | ")
+  }
+
+  override def equals(other: Any) = other match {
+      case that: DataType => that.id.name == this.id.name
+      case that: SynonymType => that.id.name == this.id.name
+      case _ => false
+    }
+  
+    override def matches(t2: Type): Boolean = this.equals(t2)
+}
+
+case class ConstructorType(id: Identifier, inTypes: List[(Identifier, Type)], outTyp: Type) extends Type {
+  override def toString = id + " {" + inTypes.map(s => s._1 + ": " + s._2.toString()).mkString(" ") + "}"
+  override def isMap = true
+}
+
 case class ProcedureType(inTypes : List[Type], outTypes: List[Type]) extends Type {
   override def toString =
     "procedure (" + Utils.join(inTypes.map(_.toString), ", ") + ") returns " +
@@ -1221,6 +1240,7 @@ case class SynonymType(id: Identifier) extends Type {
   override def toString = id.toString
   override def equals(other: Any) = other match {
     case that: SynonymType => that.id.name == this.id.name
+    case that: DataType => that.id.name == this.id.name
     case _ => false
   }
   override def codegenUclidLang: Option[Type] = ULContext.smtToLangSynonym(id.name)

--- a/src/main/scala/uclid/smt/SMTLanguage.scala
+++ b/src/main/scala/uclid/smt/SMTLanguage.scala
@@ -199,6 +199,35 @@ case object UndefinedType extends Type {
   override def isUndefined = true
 }
 
+case class DataType(id : String, cstors : List[ConstructorType]) extends Type {
+  override val hashId = 111
+  override val hashCode = finalize(hashId, 0)
+  override val md5hashCode = computeMD5Hash
+  override def toString = "data " + cstors // TODO
+  override val typeNamePrefix = "data"
+  override def isUndefined = true
+}
+
+case class ConstructorType(id: String, inTypes: List[(String, Type)], outTyp: Type) extends Type {
+  override val hashId = 113
+  override val hashCode = computeHash(id, inTypes)
+  override val md5hashCode = computeMD5Hash(id, inTypes)
+  override def toString = {
+    "constructor " + id  + " " + inTypes // TODO add selectors to the toString
+  }
+  override def isMap = true
+  override val typeNamePrefix = "constructor"
+}
+
+case class SelfReferenceType(name: String) extends Type {
+  override val hashId = 112
+  override val hashCode = computeHash(name)
+  override val md5hashCode = computeMD5Hash(name)
+  override def toString = "self %s".format(name)
+  override def isSynonym = true
+  val typeNamePrefix = "self"
+}
+
 trait Operator extends Hashable {
   override val hashBaseId : Int = 22446 // Random number.
   def resultType(args: List[Expr]) : Type
@@ -635,7 +664,16 @@ case class RecordSelectOp(name : String) extends Operator {
     Utils.assert(args(0).typ.asInstanceOf[ProductType].hasField(name), "Field '" + name + "' does not exist in product type.")
   }
   def resultType(args: List[Expr]) : Type = {
-    args(0).typ.asInstanceOf[ProductType].fieldType(name).get
+    args(0).typ match {
+      case t: TupleType => t.asInstanceOf[ProductType].fieldType(name).get
+      case r: RecordType => r.asInstanceOf[ProductType].fieldType(name).get
+      case DataType(id, cstors) => {
+        val sels = cstors.flatMap(c => c.inTypes)
+        sels.find(p => p._1 == name).get._2
+      }
+      case _ =>
+        throw new Utils.RuntimeError("Must not use symbolToZ3 on: " + args(0).typ.toString() + ".")
+    }
   }
 }
 case class RecordUpdateOp(name: String) extends Operator {
@@ -983,7 +1021,13 @@ case class LetExpression(letBindings : List[(Symbol, Expr)], expr : Expr) extend
 
 //For uninterpreted function symbols or anonymous functions defined by Lambda expressions
 case class FunctionApplication(e: Expr, args: List[Expr])
-  extends Expr (e.typ.asInstanceOf[MapType].outType)
+  extends Expr ({
+    if (e.typ.isInstanceOf[ConstructorType]) {
+      e.typ.asInstanceOf[ConstructorType].outTyp
+    } else {
+      e.typ.asInstanceOf[MapType].outType
+    }
+  })
 {
   override val hashId = 311
   override val hashCode = computeHash(args, e)

--- a/src/test/scala/ParserSpec.scala
+++ b/src/test/scala/ParserSpec.scala
@@ -45,6 +45,94 @@ import uclid.{lang => l}
 import java.io.File
 
 class ParserSpec extends AnyFlatSpec {
+  "test-adt-5-reusingdatatypename.ucl" should "not parse successfully." in {
+    try {
+      val filename = "test/test-adt-5-reusingdatatypename.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size == 1)
+    }
+  }
+  "test-adt-6-reusingselectorname.ucl" should "not parse successfully." in {
+    try {
+      val filename = "test/test-adt-6-reusingselectorname.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size == 1)
+    }
+  }
+  "test-adt-9-badconstructing.ucl" should "not typecheck." in {
+    try {
+      val filename = "test/test-adt-9-badconstructing.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+    }
+  }
+  "test-adt-10-badconstructing.ucl" should "not typecheck." in {
+    try {
+      val filename = "test/test-adt-10-badconstructing.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size == 1)
+    }
+  }
+  "test-adt-11-badconstructing.ucl" should "not typecheck." in {
+    try {
+      val filename = "test/test-adt-11-badconstructing.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size > 0)
+    }
+  }
+  "test-adt-12-badselecting.ucl" should "not typecheck." in {
+    try {
+      val filename = "test/test-adt-12-badselecting.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.TypeErrorList =>
+        assert (p.errors.size > 0)
+    }
+  }
+  "test-adt-13-badselecting.ucl" should "not parse successfully." in {
+    try {
+      val filename = "test/test-adt-13-badselecting.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size == 1)
+    }
+  }
+  "test-adt-15-multiplemodules.ucl" should "not parse successfully." in {
+    try {
+      val filename = "test/test-adt-15-multiplemodules.ucl"
+      val fileModules = UclidMain.compile(ConfigCons.createConfig(filename), lang.Identifier("main"))
+      assert (fileModules.size == 1)
+    }
+    catch {
+      case p : Utils.ParserErrorList =>
+        assert (p.errors.size > 0)
+    }
+  }
   "test-type1.ucl" should "not parse successfully." in {
     try {
       val filename = "test/test-type1.ucl"

--- a/src/test/scala/VerifierSpec.scala
+++ b/src/test/scala/VerifierSpec.scala
@@ -88,6 +88,37 @@ class VerifierSanitySpec extends AnyFlatSpec {
   "test-assert-1.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-assert-1.ucl", 0)
   }
+  "test-adt-0.ucl" should "verify all but one assertion." in {
+    VerifierSpec.expectedFails("./test/test-adt-0.ucl", 1)
+  }
+  "test-adt-1.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-adt-1.ucl", 0)
+  }
+  "test-adt-2.ucl" should "fail to verify 6 assertions." in {
+    VerifierSpec.expectedFails("./test/test-adt-2.ucl", 6)
+  }
+  "test-adt-3.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-adt-3.ucl", 0)
+  }
+  "test-adt-4.ucl" should "fail to verify 2 assertions." in {
+    VerifierSpec.expectedFails("./test/test-adt-4.ucl", 2)
+  }
+
+  "test-adt-7-testingacyclicality.ucl" should "fail to verify 3 assertions." in {
+    VerifierSpec.expectedFails("./test/test-adt-7-testingacyclicality.ucl", 3)
+  }
+  "test-adt-8-testingacyclicality.ucl" should "fail to verify 3 assertions." in {
+    VerifierSpec.expectedFails("./test/test-adt-8-testingacyclicality.ucl", 3)
+  }
+  "test-adt-14-goodselecting.ucl" should "fail to verify 2 assertions." in {
+    VerifierSpec.expectedFails("./test/test-adt-14-goodselecting.ucl", 2)
+  }
+  "test-adt-16-multiplemodules.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-adt-16-multiplemodules.ucl", 0)
+  }
+  "test-adt-17-procedures.ucl" should "verify successfully." in {
+    VerifierSpec.expectedFails("./test/test-adt-17-procedures.ucl", 0)
+  }
   "test-array-0.ucl" should "verify successfully." in {
     VerifierSpec.expectedFails("./test/test-array-0.ucl", 0)
   }

--- a/test/test-adt-0.ucl
+++ b/test/test-adt-0.ucl
@@ -1,0 +1,23 @@
+module main {
+    // should pass
+
+    datatype list = cons(head: integer, tail: list) | nil() ;
+
+    var l : list;
+
+    init {
+        l = nil();
+    }
+    
+    next {
+        l' = cons(1, l);
+    }
+
+    invariant test : l.head == 1;
+
+    control {
+        induction;
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-1.ucl
+++ b/test/test-adt-1.ucl
@@ -1,0 +1,28 @@
+module main {
+    // should pass
+    // TODO: parser error when selector name ommitted
+
+    datatype tree = join(left: tree, right: tree) | leaf(node: integer);
+
+    var t1 : tree;
+    var t2 : tree;
+
+
+    init {
+        t1 = join(leaf(1), leaf(1));
+        t2 = leaf(1);
+    }
+    
+    next {
+        t1' = join(t1, t1);
+        t2' = join(t2, t2);
+    }
+
+    invariant test : t1.left == t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-10-badconstructing.ucl
+++ b/test/test-adt-10-badconstructing.ucl
@@ -1,0 +1,20 @@
+module main {
+    // should parse error on line 11
+
+    datatype list = cons(head: integer, tail: list) | nil();
+
+
+    var l1 : list;
+    var l2: list;
+
+    init {
+        l1 = cons();
+    }
+
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-11-badconstructing.ucl
+++ b/test/test-adt-11-badconstructing.ucl
@@ -1,0 +1,20 @@
+module main {
+    // should parse error on line 11
+
+    datatype list = cons(head: integer, tail: list) | nil();
+
+
+    var l1 : list;
+    var l2: list;
+
+    init {
+        l1 = cons(l2, l2);
+    }
+
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-12-badselecting.ucl
+++ b/test/test-adt-12-badselecting.ucl
@@ -1,0 +1,20 @@
+module main {
+    // should parse error on line 11
+
+    datatype list = cons(head: integer, tail: list) | nil();
+    datatype tree = | join(left: list, right: list) | leaf(node: integer);
+
+    var l1 : list;
+    var l2: list;
+
+    init {
+        l1 = l2.left;
+    }
+
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-13-badselecting.ucl
+++ b/test/test-adt-13-badselecting.ucl
@@ -1,0 +1,20 @@
+module main {
+    // should parse error on line 11
+
+    datatype list = cons(head: integer, tail: list) | nil();
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+    var l1 : list;
+    var l2: tree;
+
+    init {
+        l1 = l2.left;
+    }
+
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-14-goodselecting.ucl
+++ b/test/test-adt-14-goodselecting.ucl
@@ -1,0 +1,26 @@
+module main {
+    // should fail
+
+    datatype list = cons(head: integer, tail: list) | nil();
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+    var l1 : tree;
+    var l2: tree;
+
+    init {
+        l1 = l2.left;
+        havoc l2;
+    }
+
+    next { 
+        l1' = l2.left;
+    }
+
+    invariant test : l1 == leaf(1);
+
+    control {
+        induction;
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-15-multiplemodules.ucl
+++ b/test/test-adt-15-multiplemodules.ucl
@@ -1,0 +1,33 @@
+module aux {
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+}
+
+module main {
+    // parse error at line 10 but only if we includ line 8
+    type * = aux.*;
+
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+    var t1 : tree;
+    var t2 : tree;
+
+
+    init {
+        t1 = join(leaf(1), leaf(1));
+        t2 = leaf(1);
+    }
+    
+    next {
+        t1' = join(t1, t1);
+        t2' = join(t2, t2);
+    }
+
+    invariant test : t1.left == t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-16-multiplemodules.ucl
+++ b/test/test-adt-16-multiplemodules.ucl
@@ -1,0 +1,33 @@
+module aux {
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+}
+
+
+
+module main {
+    // should pass
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+    var t1 : tree;
+    var t2 : tree;
+
+
+    init {
+        t1 = join(leaf(1), leaf(1));
+        t2 = leaf(1);
+    }
+    
+    next {
+        t1' = join(t1, t1);
+        t2' = join(t2, t2);
+    }
+
+    invariant test : t1.left == t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-17-procedures.ucl
+++ b/test/test-adt-17-procedures.ucl
@@ -1,0 +1,38 @@
+
+module main {
+    // should pass
+    datatype tree = | join(left: tree, right: tree) | leaf(node: integer);
+
+     // flip tree
+    procedure flip_tree(t: tree)
+    returns (new_tree : tree)
+    {
+        var l : tree;
+        var r : tree;
+        l = t.left;
+        r = t.right;
+        new_tree = join(r, l);
+    }
+
+    var t1 : tree;
+    var t2 : tree;
+
+
+    init {
+        t1 = join(leaf(1), leaf(1));
+        t2 = leaf(1);
+    }
+    
+    next {
+        call (t1') = flip_tree(join(t1, t1));
+        call (t2') = flip_tree(join(t2, t2));
+    }
+
+    invariant test : t1.left == t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-2.ucl
+++ b/test/test-adt-2.ucl
@@ -1,0 +1,34 @@
+module main {
+    // should fail
+    // TODO: fix parser so we don't have to write A() with brackets for constants
+
+    datatype myEnum = A() | B();
+
+    var t1 : myEnum;
+    var t2 : myEnum;
+
+
+    init {
+        t1 = A();
+        t2 = B();
+    }
+    
+    next {
+        case
+            (t1 == A()) : {t1' = B();}
+            (t1 == B()) : {t1' = A();}
+        esac
+        case
+            (t2 == A()) : {t2' = B();}
+            (t2 == B()) : {t2' = A();}
+        esac
+    }
+
+    invariant test : t1 == t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-3.ucl
+++ b/test/test-adt-3.ucl
@@ -1,0 +1,26 @@
+module main {
+    // should pass
+    datatype myRecord = | rec(A: integer, B: integer, C: integer);
+
+    var t1 : myRecord;
+    var t2 : myRecord;
+
+
+    init {
+        t1 = rec(1, 2, 3);
+        t2 = rec(3, 2, 1);
+    }
+    
+    next {
+        t1' = rec(t1.C, t1.A, t1.B);
+        t2' = rec(t2.C, t2.A, t2.B);
+    }
+
+    invariant test : t1 != t2;
+
+    control {
+        induction;
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-4.ucl
+++ b/test/test-adt-4.ucl
@@ -1,0 +1,25 @@
+module main {
+    // should fail every third step
+    datatype myRecord = | rec(A: integer, B: integer, C: integer);
+
+    var t1 : myRecord;
+    var t2 : myRecord;
+
+
+    init {
+        t1 = rec(1, 2, 3);
+        t2 = rec(3, 1, 2);
+    }
+    
+    next {
+        t2' = rec(t2.C, t2.A, t2.B);
+    }
+
+    invariant test : t1 != t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-5-reusingdatatypename.ucl
+++ b/test/test-adt-5-reusingdatatypename.ucl
@@ -1,0 +1,26 @@
+module main {
+    // should throw a parse error on line 4
+    datatype myRecord = | rec(A: integer, B: integer, C: integer);
+    datatype myRecord = | rec2(E: integer, F: integer, G: integer);    
+
+    var t1 : myRecord;
+    var t2 : myRecord;
+
+
+    init {
+        t1 = rec(1, 2, 3);
+        t2 = rec(3, 1, 2);
+    }
+    
+    next {
+        t2' = t2;
+    }
+
+    invariant test : t1 != t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-6-reusingselectorname.ucl
+++ b/test/test-adt-6-reusingselectorname.ucl
@@ -1,0 +1,26 @@
+module main {
+    // should throw a parse error on line 4
+    datatype myRecord1 = | rec1(A: integer, B: integer, C: integer);
+    datatype myRecord = | rec(A: integer, F: integer, G: integer);    
+
+    var t1 : myRecord;
+    var t2 : myRecord;
+
+
+    init {
+        t1 = rec(1, 2, 3);
+        t2 = rec(3, 1, 2);
+    }
+    
+    next {
+        t2' = t2;
+    }
+
+    invariant test : t1 != t2;
+
+    control {
+        bmc(5);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-7-testingacyclicality.ucl
+++ b/test/test-adt-7-testingacyclicality.ucl
@@ -1,0 +1,19 @@
+module main {
+
+    datatype list = cons(head: integer, tail: list) | nil();
+
+    var l : list;
+
+    init {
+        l = nil();
+    }
+    
+
+    invariant test : l.tail == l && l == nil();
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-8-testingacyclicality.ucl
+++ b/test/test-adt-8-testingacyclicality.ucl
@@ -1,0 +1,16 @@
+module main {
+    // should fail
+
+    datatype list = cons(head: integer, tail: list) | nil();
+
+    var l1 : list;
+    var l2: list;
+
+    invariant test : l1.tail == l2 && l2.tail == l1 && l1 != nil() && l2 != nil();
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}

--- a/test/test-adt-9-badconstructing.ucl
+++ b/test/test-adt-9-badconstructing.ucl
@@ -1,0 +1,20 @@
+module main {
+    // should parse error on line 11
+
+    datatype list = cons(head: integer, tail: list) | nil();
+
+
+    var l1 : list;
+    var l2: list;
+
+    init {
+        l1 = cons(l1);
+    }
+
+
+    control {
+        bmc(2);
+        check;
+        print_results;
+    }
+}


### PR DESCRIPTION
Sorry for the delay with adding this. @FedericoAureliano and I have added the `datatype` type to UCLID. There are 18 tests that fail parsing, fail typechecking, pass verification, and fail verification. Here is an example:

```
module main {
    // should fail every third step
    datatype myRecord = | rec(A: integer, B: integer, C: integer);

    var t1 : myRecord;
    var t2 : myRecord;


    init {
        t1 = rec(1, 2, 3);
        t2 = rec(3, 1, 2);
    }
    
    next {
        t2' = rec(t2.C, t2.A, t2.B);
    }

    invariant test : t1 != t2;

    control {
        bmc(5);
        check;
        print_results;
    }
}
```

Output:

```
Successfully instantiated 1 module(s).
4 assertions passed.
2 assertions failed.
0 assertions indeterminate.
  PASSED -> bmc [Step #0] property test @ test/test-adt-4.ucl, line 18
  PASSED -> bmc [Step #1] property test @ test/test-adt-4.ucl, line 18
  PASSED -> bmc [Step #3] property test @ test/test-adt-4.ucl, line 18
  PASSED -> bmc [Step #4] property test @ test/test-adt-4.ucl, line 18
  FAILED -> bmc [Step #2] property test @ test/test-adt-4.ucl, line 18
  FAILED -> bmc [Step #5] property test @ test/test-adt-4.ucl, line 18
Finished execution for module: main.
```

Enum and record support in UCLID could be folded into this in the future. We do not currently have support for testers, mutually recursive datatypes, and parametric datatypes. Let me know if there is anything we should add to this pull request.